### PR TITLE
Add weak-word drill mode and manual registration

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -55,7 +55,7 @@ model WeakWord {
 model Session {
   id               String            @id @default(cuid())
   userId           String
-  mode             String            @default("sentence") // "sentence" | "weak_word" | "random"
+  mode             String            @default("sentence") // "sentence" | "weak_word" | "random" | "word_drill"
   totalKeys        Int
   missKeys         Int
   durationMs       Int

--- a/backend/src/lib/weakWordMetrics.ts
+++ b/backend/src/lib/weakWordMetrics.ts
@@ -6,6 +6,7 @@ export type WeaknessReason = 'mistype' | 'slow' | 'stall'
 
 interface WordWeaknessMetrics {
   word: string
+  totalChars: number
   misses: number
   activeDurationMs: number
   stallCount: number
@@ -40,8 +41,9 @@ function getReasonComponents(metrics: {
 }
 
 export function calculateWeakWordMetrics(word: WordWeaknessMetrics): SavedWeakWordMetrics {
-  const missRate = word.word.length > 0 ? word.misses / word.word.length : 0
-  const msPerChar = word.word.length > 0 ? word.activeDurationMs / word.word.length : 0
+  const totalChars = word.totalChars > 0 ? word.totalChars : word.word.length
+  const missRate = totalChars > 0 ? word.misses / totalChars : 0
+  const msPerChar = totalChars > 0 ? word.activeDurationMs / totalChars : 0
   const reasonComponents = getReasonComponents({
     misses: word.misses,
     missRate,

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -4,12 +4,13 @@ import { prisma } from '../db.js'
 import { calculateWeakWordMetrics } from '../lib/weakWordMetrics.js'
 import { authenticateJWT } from '../middleware/authenticate.js'
 
-const VALID_MODES = ['sentence', 'random', 'weak_word'] as const
+const VALID_MODES = ['sentence', 'random', 'weak_word', 'word_drill'] as const
 
 type Mode = (typeof VALID_MODES)[number]
 
 interface SessionWordInput {
   word: string
+  totalChars: number
   misses: number
   activeDurationMs: number
   stallCount: number
@@ -64,10 +65,11 @@ function parseWords(value: unknown): SessionWordInput[] | null {
       return null
     }
 
-    const { word, misses, activeDurationMs, stallCount, stallDurationMs } = item as Record<string, unknown>
+    const { word, totalChars, misses, activeDurationMs, stallCount, stallDurationMs } = item as Record<string, unknown>
     if (
       typeof word !== 'string'
       || word.length === 0
+      || !isPositiveInteger(totalChars)
       || !isNonNegativeInteger(misses)
       || !isNonNegativeInteger(activeDurationMs)
       || !isNonNegativeInteger(stallCount)
@@ -76,7 +78,7 @@ function parseWords(value: unknown): SessionWordInput[] | null {
       return null
     }
 
-    words.push({ word, misses, activeDurationMs, stallCount, stallDurationMs })
+    words.push({ word, totalChars, misses, activeDurationMs, stallCount, stallDurationMs })
   }
 
   return words
@@ -119,7 +121,7 @@ export default async function sessionRoutes(app: FastifyInstance) {
 
     const mode = parseMode(body.mode)
     if (!mode) {
-      return sendBadRequest(reply, 'mode must be one of sentence, random, weak_word')
+      return sendBadRequest(reply, 'mode must be one of sentence, random, weak_word, word_drill')
     }
     if (!isNonNegativeInteger(totalKeys)) {
       return sendBadRequest(reply, 'totalKeys must be a non-negative integer')
@@ -143,7 +145,7 @@ export default async function sessionRoutes(app: FastifyInstance) {
     if (!words) {
       return sendBadRequest(
         reply,
-        'words must be an array of { word, misses, activeDurationMs, stallCount, stallDurationMs } with non-negative integer metrics',
+        'words must be an array of { word, totalChars, misses, activeDurationMs, stallCount, stallDurationMs } with valid integer metrics',
       )
     }
 
@@ -168,7 +170,8 @@ export default async function sessionRoutes(app: FastifyInstance) {
     }
 
     const session = await prisma.$transaction(async (tx) => {
-      const existingWeakWords = words.length > 0
+      const shouldUpdateWeakWords = mode !== 'word_drill'
+      const existingWeakWords = shouldUpdateWeakWords && words.length > 0
         ? new Set(
             (await tx.weakWord.findMany({
               where: { userId, word: { in: words.map((word) => word.word) } },
@@ -209,36 +212,38 @@ export default async function sessionRoutes(app: FastifyInstance) {
           })),
         })
 
-        for (const word of words) {
-          const metrics = calculateWeakWordMetrics(word)
-          if (metrics.weaknessScore <= 0 && mode !== 'weak_word' && !existingWeakWords.has(word.word)) {
-            continue
-          }
+        if (shouldUpdateWeakWords) {
+          for (const word of words) {
+            const metrics = calculateWeakWordMetrics(word)
+            if (metrics.weaknessScore <= 0 && mode !== 'weak_word' && !existingWeakWords.has(word.word)) {
+              continue
+            }
 
-          await tx.weakWord.upsert({
-            where: { userId_word: { userId, word: word.word } },
-            create: {
-              userId,
-              word: word.word,
-              missRate: metrics.missRate,
-              activeDurationMs: word.activeDurationMs,
-              msPerChar: metrics.msPerChar,
-              stallCount: word.stallCount,
-              stallDurationMs: word.stallDurationMs,
-              weaknessScore: metrics.weaknessScore,
-              primaryReason: metrics.primaryReason,
-              isSolved: false,
-            },
-            update: {
-              missRate: metrics.missRate,
-              activeDurationMs: word.activeDurationMs,
-              msPerChar: metrics.msPerChar,
-              stallCount: word.stallCount,
-              stallDurationMs: word.stallDurationMs,
-              weaknessScore: metrics.weaknessScore,
-              primaryReason: metrics.primaryReason,
-            },
-          })
+            await tx.weakWord.upsert({
+              where: { userId_word: { userId, word: word.word } },
+              create: {
+                userId,
+                word: word.word,
+                missRate: metrics.missRate,
+                activeDurationMs: word.activeDurationMs,
+                msPerChar: metrics.msPerChar,
+                stallCount: word.stallCount,
+                stallDurationMs: word.stallDurationMs,
+                weaknessScore: metrics.weaknessScore,
+                primaryReason: metrics.primaryReason,
+                isSolved: false,
+              },
+              update: {
+                missRate: metrics.missRate,
+                activeDurationMs: word.activeDurationMs,
+                msPerChar: metrics.msPerChar,
+                stallCount: word.stallCount,
+                stallDurationMs: word.stallDurationMs,
+                weaknessScore: metrics.weaknessScore,
+                primaryReason: metrics.primaryReason,
+              },
+            })
+          }
         }
       }
 

--- a/backend/src/routes/weakWords.ts
+++ b/backend/src/routes/weakWords.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../db.js'
 import { authenticateJWT } from '../middleware/authenticate.js'
 
+const MAX_WORD_LENGTH = 200
 const MAX_NOTE_LENGTH = 5000
 
 const weakWordSelect = {
@@ -21,6 +22,65 @@ const weakWordSelect = {
 } as const
 
 export default async function weakWordRoutes(app: FastifyInstance) {
+  app.post(
+    '/weak-words',
+    { preHandler: [authenticateJWT] },
+    async (req, reply) => {
+      const userId = req.user!.id
+      const body = (req.body ?? {}) as { word?: unknown; note?: unknown }
+
+      if (typeof body.word !== 'string' || !body.word.trim()) {
+        return reply.status(400).send({ message: 'word is required' })
+      }
+
+      const word = body.word.trim()
+      if (word.length > MAX_WORD_LENGTH) {
+        return reply.status(400).send({ message: `word must be ${MAX_WORD_LENGTH} chars or less` })
+      }
+      if (/\s/.test(word)) {
+        return reply.status(400).send({ message: 'word must be a single token without spaces' })
+      }
+
+      let note: string | null = null
+      if ('note' in body) {
+        if (typeof body.note !== 'string') {
+          return reply.status(400).send({ message: 'note must be a string' })
+        }
+        if (body.note.length > MAX_NOTE_LENGTH) {
+          return reply.status(400).send({ message: `note must be ${MAX_NOTE_LENGTH} chars or less` })
+        }
+        note = body.note.trim() || null
+      }
+
+      const existing = await prisma.weakWord.findUnique({
+        where: { userId_word: { userId, word } },
+        select: weakWordSelect,
+      })
+      if (existing) {
+        return reply.status(200).send({ word: existing, created: false })
+      }
+
+      const created = await prisma.weakWord.create({
+        data: {
+          userId,
+          word,
+          note,
+          missRate: 0,
+          activeDurationMs: 0,
+          msPerChar: 0,
+          stallCount: 0,
+          stallDurationMs: 0,
+          weaknessScore: 0,
+          primaryReason: null,
+          isSolved: false,
+        },
+        select: weakWordSelect,
+      })
+
+      return reply.status(201).send({ word: created, created: true })
+    },
+  )
+
   app.get(
     '/weak-words',
     { preHandler: [authenticateJWT] },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ import type { Sentence } from './lib/sentences'
 import { listWeakWords } from './lib/weakWords'
 import { listWeakBigrams, fetchWordsForBigrams } from './lib/bigramStats'
 
-type SessionMode = 'sentence' | 'random' | 'weak_word'
+type SessionMode = 'sentence' | 'random' | 'weak_word' | 'word_drill'
 
 interface SessionText {
   text: string
@@ -49,6 +49,14 @@ function normalizeText(text: string): string {
 
 const RANDOM_TEXT_LENGTH = 30
 const MAX_WEAK_WORD_QUESTIONS = 10
+
+function createWordDrillItems(word: string, count: number): SessionText[] {
+  const text = normalizeText(word)
+  return Array.from({ length: count }, () => ({
+    text,
+    sentenceId: null,
+  }))
+}
 
 function generateRandomSessionItems(): SessionText[] {
   return [{
@@ -259,6 +267,14 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
     })
   }, [beginSession, location.pathname])
 
+  const handleStartWordDrill = useCallback((word: string, count: number) => {
+    beginSession({
+      mode: 'word_drill',
+      items: createWordDrillItems(word, count),
+      returnPath: '/weak-words',
+    })
+  }, [beginSession])
+
   const handleSessionComplete = useCallback((result: SessionResult) => {
     if (!activeSession) return
 
@@ -287,6 +303,7 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
         ? []
         : result.allWordStats.map((word) => ({
             word: word.word,
+            totalChars: word.totalChars,
             misses: word.misses,
             activeDurationMs: word.activeDurationMs,
             stallCount: word.stallCount,
@@ -378,6 +395,7 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
         element={(
           <WeakWordManager
             onStartWeakWordSession={handleStartWeakWordSession}
+            onStartWordDrill={handleStartWordDrill}
             onStartRandomSession={handleStartRandomSession}
             isMockMode={isMockMode}
             onLogout={handleLogout}
@@ -401,6 +419,7 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
         path="/practice"
         element={activeSession ? (
           <PracticeScreen
+            mode={activeSession.mode}
             sessionItems={activeSession.items}
             onComplete={handleSessionComplete}
             onAbort={handleAbortSession}

--- a/frontend/src/components/PracticeScreen/PracticeScreen.tsx
+++ b/frontend/src/components/PracticeScreen/PracticeScreen.tsx
@@ -10,6 +10,7 @@ interface SessionText {
 }
 
 interface Props {
+  mode: 'sentence' | 'random' | 'weak_word' | 'word_drill'
   sessionItems: SessionText[]
   onComplete: (result: SessionResult) => void
   onAbort: () => void
@@ -24,6 +25,7 @@ function getReturnLabel(returnPath: string): string {
 }
 
 export function PracticeScreen({
+  mode,
   sessionItems,
   onComplete,
   onAbort,
@@ -35,13 +37,15 @@ export function PracticeScreen({
   const [lockRemaining, setLockRemaining] = useState(0)
   const completedRef = useRef(false)
   const liveFeedback = useMemo(
-    () => getLiveTypingFeedback({
-      text: engineState.text,
-      keyHistory: engineState.keyHistory,
-      startedAt: engineState.startedAt,
-      cursor: engineState.cursor,
-    }),
-    [engineState.cursor, engineState.keyHistory, engineState.startedAt, engineState.text],
+    () => (mode === 'word_drill'
+      ? null
+      : getLiveTypingFeedback({
+          text: engineState.text,
+          keyHistory: engineState.keyHistory,
+          startedAt: engineState.startedAt,
+          cursor: engineState.cursor,
+        })),
+    [engineState.cursor, engineState.keyHistory, engineState.startedAt, engineState.text, mode],
   )
 
   useEffect(() => {
@@ -115,19 +119,21 @@ export function PracticeScreen({
           <TypingArea state={engineState} onKey={handleKey} lockRemaining={lockRemaining} />
         </div>
 
-        <div className="w-full h-8">
-          {liveFeedback && (
-            <div
-              className={`inline-flex items-center rounded-full border px-3 py-1 text-xs transition-colors ${
-                liveFeedback.reason === 'stall'
-                  ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
-                  : 'border-sky-500/40 bg-sky-500/10 text-sky-300'
-              }`}
-            >
-              {liveFeedback.message}
-            </div>
-          )}
-        </div>
+        {mode !== 'word_drill' && (
+          <div className="w-full h-8">
+            {liveFeedback && (
+              <div
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs transition-colors ${
+                  liveFeedback.reason === 'stall'
+                    ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+                    : 'border-sky-500/40 bg-sky-500/10 text-sky-300'
+                }`}
+              >
+                {liveFeedback.message}
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="w-full h-14 overflow-hidden">
           {nextText ? (

--- a/frontend/src/components/ResultsScreen/ResultsScreen.tsx
+++ b/frontend/src/components/ResultsScreen/ResultsScreen.tsx
@@ -3,7 +3,7 @@ import type { SessionResult } from '../../hooks/useTypingSession'
 import { formatWeaknessReason } from '../../lib/typingAnalysis'
 
 interface Props {
-  mode: 'sentence' | 'random' | 'weak_word'
+  mode: 'sentence' | 'random' | 'weak_word' | 'word_drill'
   result: SessionResult
   totalCount: number
   onRestart: () => void
@@ -30,9 +30,12 @@ export function ResultsScreen({
 
   const title = mode === 'weak_word'
     ? '苦手ワード練習結果'
+    : mode === 'word_drill'
+      ? 'ワードドリル結果'
     : mode === 'random'
       ? 'ランダムワード練習結果'
       : 'セッション結果'
+  const completedLabel = mode === 'word_drill' ? '回完了' : '問完了'
 
   useEffect(() => {
     function handleRestartKey(event: KeyboardEvent) {
@@ -59,7 +62,7 @@ export function ResultsScreen({
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center justify-start py-12 px-6">
       <h2 className="text-3xl font-bold mb-2">{title}</h2>
-      <p className="text-gray-500 text-sm mb-8">{totalCount} 問完了 / R でリスタート</p>
+      <p className="text-gray-500 text-sm mb-8">{totalCount} {completedLabel} / R でリスタート</p>
 
       {/* サマリー指標 */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 w-full max-w-2xl mb-10">

--- a/frontend/src/components/SentenceManager/WeakWordList.tsx
+++ b/frontend/src/components/SentenceManager/WeakWordList.tsx
@@ -7,9 +7,10 @@ interface Props {
   onUpdateNote: (id: string, note: string) => Promise<void>
   onToggleSolved: (id: string, isSolved: boolean) => Promise<void>
   onDelete: (id: string) => Promise<void>
+  onDrill: (word: WeakWord) => void
 }
 
-const GRID_COLUMNS = 'grid-cols-[minmax(0,1fr)_9rem_13rem_6.5rem_14rem_8.5rem]'
+const GRID_COLUMNS = 'grid-cols-[minmax(0,1fr)_9rem_13rem_6.5rem_minmax(0,1fr)_11rem]'
 
 function getWeakWordReasons(weakWord: WeakWord) {
   return getWeaknessReasons({
@@ -47,11 +48,12 @@ function WeakWordMetrics({ weakWord }: { weakWord: WeakWord }) {
   )
 }
 
-function WeakWordRow({ weakWord, onUpdateNote, onToggleSolved, onDelete }: {
+function WeakWordRow({ weakWord, onUpdateNote, onToggleSolved, onDelete, onDrill }: {
   weakWord: WeakWord
   onUpdateNote: (id: string, note: string) => Promise<void>
   onToggleSolved: (id: string, isSolved: boolean) => Promise<void>
   onDelete: (id: string) => Promise<void>
+  onDrill: (word: WeakWord) => void
 }) {
   const [editing, setEditing] = useState(false)
   const [editNote, setEditNote] = useState(weakWord.note ?? '')
@@ -190,6 +192,12 @@ function WeakWordRow({ weakWord, onUpdateNote, onToggleSolved, onDelete }: {
         ) : (
           <>
             <button
+              onClick={() => onDrill(weakWord)}
+              className="rounded-md border border-sky-500/40 px-2 py-1 text-xs text-sky-300 hover:bg-sky-500/10"
+            >
+              ドリル
+            </button>
+            <button
               onClick={() => setEditing(true)}
               className="rounded-md border border-amber-500/40 px-2 py-1 text-xs text-amber-300 hover:bg-amber-500/10"
             >
@@ -208,7 +216,7 @@ function WeakWordRow({ weakWord, onUpdateNote, onToggleSolved, onDelete }: {
   )
 }
 
-export function WeakWordList({ weakWords, onUpdateNote, onToggleSolved, onDelete }: Props) {
+export function WeakWordList({ weakWords, onUpdateNote, onToggleSolved, onDelete, onDrill }: Props) {
   if (weakWords.length === 0) {
     return (
       <div className="text-center py-12 text-gray-500 text-sm">
@@ -234,6 +242,7 @@ export function WeakWordList({ weakWords, onUpdateNote, onToggleSolved, onDelete
           onUpdateNote={onUpdateNote}
           onToggleSolved={onToggleSolved}
           onDelete={onDelete}
+          onDrill={onDrill}
         />
       ))}
     </div>

--- a/frontend/src/components/SentenceManager/WeakWordManager.tsx
+++ b/frontend/src/components/SentenceManager/WeakWordManager.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DashboardLayout } from '../Layout/DashboardLayout'
 import { WeakWordList } from './WeakWordList'
+import { WordDrillModal } from './WordDrillModal'
 import {
+  createWeakWord,
   deleteWeakWord as deleteWeakWordRequest,
   listWeakWords,
   updateWeakWord,
@@ -10,6 +12,7 @@ import {
 
 interface Props {
   onStartWeakWordSession: () => Promise<void>
+  onStartWordDrill: (word: string, count: number) => void
   onStartRandomSession: () => void
   isMockMode: boolean
   onLogout: () => void
@@ -18,6 +21,7 @@ interface Props {
 
 export function WeakWordManager({
   onStartWeakWordSession,
+  onStartWordDrill,
   onStartRandomSession,
   isMockMode,
   onLogout,
@@ -29,6 +33,10 @@ export function WeakWordManager({
   const [practiceError, setPracticeError] = useState<string | null>(null)
   const [startingWeakWordSession, setStartingWeakWordSession] = useState(false)
   const [hideSolved, setHideSolved] = useState(true)
+  const [addWordInput, setAddWordInput] = useState('')
+  const [addWordLoading, setAddWordLoading] = useState(false)
+  const [addWordFeedback, setAddWordFeedback] = useState<{ kind: 'error' | 'info'; message: string } | null>(null)
+  const [drillTarget, setDrillTarget] = useState<WeakWord | null>(null)
 
   const loadWeakWords = useCallback(async () => {
     if (isMockMode) {
@@ -74,6 +82,50 @@ export function WeakWordManager({
     await deleteWeakWordRequest(id)
     setWeakWords((current) => current.filter((word) => word.id !== id))
   }, [])
+
+  const handleAddWord = useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const word = addWordInput.trim()
+    if (!word) {
+      setAddWordFeedback({ kind: 'error', message: '追加するワードを入力してください。' })
+      return
+    }
+    if (/\s/.test(word)) {
+      setAddWordFeedback({ kind: 'error', message: 'ワードは1語ずつ追加してください。' })
+      return
+    }
+
+    setAddWordLoading(true)
+    setAddWordFeedback(null)
+    try {
+      const result = await createWeakWord(word)
+      setWeakWords((current) => [
+        result.word,
+        ...current.filter((item) => item.id !== result.word.id),
+      ])
+      setAddWordInput('')
+      setAddWordFeedback({
+        kind: 'info',
+        message: result.created
+          ? `「${result.word.word}」を追加しました。`
+          : `「${result.word.word}」はすでに登録されています。`,
+      })
+    } catch (err) {
+      setAddWordFeedback({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'ワードの追加に失敗しました',
+      })
+    } finally {
+      setAddWordLoading(false)
+    }
+  }, [addWordInput])
+
+  const handleStartDrill = useCallback((word: string, count: number) => {
+    setDrillTarget(null)
+    setPracticeError(null)
+    onStartWordDrill(word, count)
+  }, [onStartWordDrill])
 
   const activeCount = useMemo(() => weakWords.filter((word) => !word.isSolved).length, [weakWords])
   const visibleWeakWords = useMemo(
@@ -146,11 +198,49 @@ export function WeakWordManager({
           </div>
         </div>
       ) : (
-        <WeakWordList
-          weakWords={visibleWeakWords}
-          onUpdateNote={(id, note) => handleUpdateWeakWord(id, { note })}
-          onToggleSolved={(id, isSolved) => handleUpdateWeakWord(id, { isSolved })}
-          onDelete={handleDeleteWeakWord}
+        <div className="space-y-4">
+          <form onSubmit={handleAddWord} className="rounded-xl border border-gray-700 bg-gray-800/50 p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+              <div className="min-w-0 flex-1">
+                <label className="mb-2 block text-sm font-semibold text-gray-300">ワードを手動追加</label>
+                <input
+                  type="text"
+                  value={addWordInput}
+                  onChange={(e) => setAddWordInput(e.target.value)}
+                  placeholder="例: acquisition"
+                  className="w-full rounded-lg bg-gray-700 px-4 py-2 font-mono text-gray-100 outline-none transition focus:ring-2 focus:ring-amber-500"
+                />
+                {addWordFeedback && (
+                  <p className={`mt-2 text-sm ${addWordFeedback.kind === 'error' ? 'text-red-300' : 'text-amber-300'}`}>
+                    {addWordFeedback.message}
+                  </p>
+                )}
+              </div>
+              <button
+                type="submit"
+                disabled={addWordLoading || !addWordInput.trim()}
+                className="rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-500 disabled:opacity-40"
+              >
+                {addWordLoading ? '追加中...' : '追加'}
+              </button>
+            </div>
+          </form>
+
+          <WeakWordList
+            weakWords={visibleWeakWords}
+            onUpdateNote={(id, note) => handleUpdateWeakWord(id, { note })}
+            onToggleSolved={(id, isSolved) => handleUpdateWeakWord(id, { isSolved })}
+            onDelete={handleDeleteWeakWord}
+            onDrill={(word) => setDrillTarget(word)}
+          />
+        </div>
+      )}
+
+      {drillTarget && (
+        <WordDrillModal
+          word={drillTarget}
+          onStart={handleStartDrill}
+          onClose={() => setDrillTarget(null)}
         />
       )}
     </DashboardLayout>

--- a/frontend/src/components/SentenceManager/WordDrillModal.tsx
+++ b/frontend/src/components/SentenceManager/WordDrillModal.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import type { WeakWord } from '../../lib/weakWords'
+
+interface Props {
+  word: WeakWord
+  onStart: (word: string, count: number) => void
+  onClose: () => void
+}
+
+const DRILL_COUNTS = [5, 10, 20, 30, 50] as const
+
+export function WordDrillModal({ word, onStart, onClose }: Props) {
+  const [count, setCount] = useState<number>(10)
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+      <div className="w-full max-w-lg rounded-2xl border border-gray-700 bg-gray-800 p-8 shadow-2xl">
+        <div className="space-y-5">
+          <div>
+            <h3 className="text-lg font-bold text-gray-100">ワードドリル</h3>
+            <p className="mt-2 text-sm text-gray-400">同じ単語を繰り返し打って苦手な運指を固めます。</p>
+          </div>
+
+          <div className="rounded-xl border border-gray-700 bg-gray-900/70 px-4 py-4">
+            <p className="text-xs uppercase tracking-widest text-gray-500">対象ワード</p>
+            <p className="mt-2 font-mono text-2xl text-white">{word.word}</p>
+            {word.note && (
+              <p className="mt-3 text-sm text-amber-300">{word.note}</p>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-indigo-500/30 bg-indigo-500/10 px-4 py-3 text-sm text-indigo-200">
+            速さより指の動きを意識。ゆっくり正確に打ち、慣れたら少しずつ速度を上げます。
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm text-gray-400">繰り返し回数</p>
+            <div className="flex flex-wrap gap-2">
+              {DRILL_COUNTS.map((option) => (
+                <button
+                  key={option}
+                  onClick={() => setCount(option)}
+                  className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${
+                    count === option
+                      ? 'bg-sky-600 text-white'
+                      : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                  }`}
+                >
+                  {option}回
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              onClick={() => onStart(word.word, count)}
+              className="flex-1 rounded-xl bg-amber-600 py-3 font-semibold text-white transition-colors hover:bg-amber-500"
+            >
+              ドリル開始
+            </button>
+            <button
+              onClick={onClose}
+              className="flex-1 rounded-xl bg-gray-700 py-3 text-gray-300 transition-colors hover:bg-gray-600"
+            >
+              キャンセル
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -1,13 +1,14 @@
 import { apiFetch } from './api'
 
 export interface SaveSessionRequest {
-  mode: 'sentence' | 'random' | 'weak_word'
+  mode: 'sentence' | 'random' | 'weak_word' | 'word_drill'
   totalKeys: number
   missKeys: number
   durationMs: number
   sentenceIds: string[]
   words: Array<{
     word: string
+    totalChars: number
     misses: number
     activeDurationMs: number
     stallCount: number

--- a/frontend/src/lib/typingAnalysis.test.ts
+++ b/frontend/src/lib/typingAnalysis.test.ts
@@ -77,6 +77,43 @@ describe('analyzeProblems', () => {
     })
     expect(result.wordStats[0].weaknessReasons).toEqual(['stall'])
   })
+
+  it('averages metrics across repeated occurrences of the same word', () => {
+    const result = analyzeProblems([
+      {
+        text: 'cat ',
+        startedAt: 0,
+        endedAt: 200,
+        keyHistory: [
+          { key: 'c', correct: true, timestamp: 0, position: 0 },
+          { key: 'a', correct: true, timestamp: 100, position: 1 },
+          { key: 't', correct: true, timestamp: 200, position: 2 },
+        ],
+      },
+      {
+        text: 'cat ',
+        startedAt: 0,
+        endedAt: 150,
+        keyHistory: [
+          { key: 'c', correct: true, timestamp: 0, position: 0 },
+          { key: 'x', correct: false, timestamp: 50, position: 1 },
+          { key: 'a', correct: true, timestamp: 100, position: 1 },
+          { key: 't', correct: true, timestamp: 150, position: 2 },
+        ],
+      },
+    ])
+
+    expect(result.wordStats).toHaveLength(1)
+    expect(result.wordStats[0]).toMatchObject({
+      word: 'cat',
+      totalChars: 6,
+      misses: 1,
+      activeDurationMs: 300,
+      missRate: 0.17,
+      msPerChar: 50,
+    })
+    expect(result.wordStats[0].weaknessReasons).toEqual(['mistype'])
+  })
 })
 
 describe('getLiveTypingFeedback', () => {

--- a/frontend/src/lib/typingAnalysis.ts
+++ b/frontend/src/lib/typingAnalysis.ts
@@ -15,6 +15,7 @@ export interface ProblemRecord {
 
 export interface WordStat {
   word: string
+  totalChars: number
   misses: number
   missRate: number
   activeDurationMs: number
@@ -60,7 +61,7 @@ interface WordRange {
 
 interface WordAggregate {
   word: string
-  length: number
+  totalChars: number
   misses: number
   activeDurationMs: number
   stallCount: number
@@ -112,7 +113,7 @@ function buildWordPositionMap(text: string, words: WordRange[]): Array<number | 
 function createWordAggregate(word: WordRange): WordAggregate {
   return {
     word: word.word,
-    length: word.word.length,
+    totalChars: word.word.length,
     misses: 0,
     activeDurationMs: 0,
     stallCount: 0,
@@ -181,8 +182,8 @@ export function formatWeaknessReason(reason: WeaknessReason): string {
 }
 
 function finalizeWordStat(aggregate: WordAggregate): WordStat {
-  const missRate = aggregate.length > 0 ? aggregate.misses / aggregate.length : 0
-  const msPerChar = aggregate.length > 0 ? aggregate.activeDurationMs / aggregate.length : 0
+  const missRate = aggregate.totalChars > 0 ? aggregate.misses / aggregate.totalChars : 0
+  const msPerChar = aggregate.totalChars > 0 ? aggregate.activeDurationMs / aggregate.totalChars : 0
   const metrics = {
     misses: aggregate.misses,
     missRate,
@@ -193,6 +194,7 @@ function finalizeWordStat(aggregate: WordAggregate): WordStat {
 
   return {
     word: aggregate.word,
+    totalChars: aggregate.totalChars,
     misses: aggregate.misses,
     missRate: round(missRate),
     activeDurationMs: aggregate.activeDurationMs,
@@ -229,6 +231,15 @@ export function analyzeProblems(records: ProblemRecord[]): SessionResult {
     const words = splitIntoWords(record.text)
     const wordPositionMap = buildWordPositionMap(record.text, words)
 
+    for (const word of words) {
+      const existing = wordMap.get(word.word)
+      if (existing) {
+        existing.totalChars += word.word.length
+      } else {
+        wordMap.set(word.word, createWordAggregate(word))
+      }
+    }
+
     let previousTimestamp = record.startedAt
     let previousWasMiss = false
 
@@ -246,10 +257,11 @@ export function analyzeProblems(records: ProblemRecord[]): SessionResult {
       const wordIndex = getWordIndexAtPosition(wordPositionMap, event.position)
       if (wordIndex !== null && wordIndex !== undefined) {
         const word = words[wordIndex]
-        const aggregate = wordMap.get(word.word) ?? createWordAggregate(word)
+        const aggregate = wordMap.get(word.word)
+        if (!aggregate) {
+          continue
+        }
         applyEventToWordAggregate(aggregate, event, adjustedGap)
-
-        wordMap.set(word.word, aggregate)
       }
 
       previousTimestamp = event.timestamp

--- a/frontend/src/lib/weakWords.ts
+++ b/frontend/src/lib/weakWords.ts
@@ -17,8 +17,23 @@ export interface WeakWord {
   updatedAt: string
 }
 
+export interface CreateWeakWordResponse {
+  word: WeakWord
+  created: boolean
+}
+
 export function listWeakWords(): Promise<{ words: WeakWord[] }> {
   return apiFetch<{ words: WeakWord[] }>('/api/weak-words')
+}
+
+export function createWeakWord(word: string, note?: string): Promise<CreateWeakWordResponse> {
+  return apiFetch<CreateWeakWordResponse>('/api/weak-words', {
+    method: 'POST',
+    body: JSON.stringify({
+      word,
+      ...(note !== undefined ? { note } : {}),
+    }),
+  })
 }
 
 export function updateWeakWord(


### PR DESCRIPTION
## Summary

- add manual weak-word registration from the weak words page
- add a dedicated `word_drill` practice flow with a drill modal and result screen support
- fix repeated-word metric aggregation and prevent `word_drill` from showing live weak-word feedback or updating weak-word weakness flags

## Testing

- `cd frontend && npm test -- --run`
- `cd frontend && npm run build`
- `cd backend && npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added "Word Drill" session mode for focused practice on specific weak words with configurable repeat counts (5, 10, 20, 30, 50)
* Ability to manually create weak word entries with optional notes
* Added "ドリル" button to weak word list for quick access to drill mode

**Improvements**
* Enhanced weak word metrics tracking for more accurate performance analysis
* Updated completion screen labels and messaging for word drill sessions
* Disabled live typing feedback during word drill mode for cleaner practice experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->