### PR TITLE
Add lifetime stats screen and fix typing analysis period handling

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,7 +36,7 @@ await app.register(import('./routes/sentences.js'), { prefix: '/api' })
 await app.register(import('./routes/weakWords.js'), { prefix: '/api' })
 await app.register(import('./routes/bigramStats.js'), { prefix: '/api' })
 await app.register(import('./routes/sessions.js'), { prefix: '/api' })
-// await app.register(import('./routes/stats.js'), { prefix: '/api' })
+await app.register(import('./routes/stats.js'), { prefix: '/api' })
 
 const port = Number(process.env.PORT ?? 3000)
 await app.listen({ port, host: '0.0.0.0' })

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -1,0 +1,59 @@
+import type { FastifyInstance } from 'fastify'
+import { prisma } from '../db.js'
+import { authenticateJWT } from '../middleware/authenticate.js'
+
+export default async function statsRoutes(app: FastifyInstance) {
+  // GET /api/stats/lifetime
+  // ユーザーの生涯成績を集計して返す。
+  app.get('/stats/lifetime', { preHandler: [authenticateJWT] }, async (req) => {
+    const userId = req.user!.id
+
+    const [sessionAgg, allSessions, uniqueWords, weakWordAgg, solvedCount] = await Promise.all([
+      prisma.session.aggregate({
+        where: { userId },
+        _sum: { totalKeys: true, missKeys: true, durationMs: true },
+        _count: { id: true },
+      }),
+      prisma.session.findMany({
+        where: { userId },
+        select: { totalKeys: true, missKeys: true, durationMs: true },
+      }),
+      prisma.$queryRaw<[{ cnt: bigint }]>`
+        SELECT COUNT(DISTINCT sw.word) AS cnt
+        FROM SessionWord sw
+        INNER JOIN Session s ON sw.sessionId = s.id
+        WHERE s.userId = ${userId}
+      `,
+      prisma.weakWord.aggregate({ where: { userId }, _count: { id: true } }),
+      prisma.weakWord.count({ where: { userId, isSolved: true } }),
+    ])
+
+    const totalKeys = sessionAgg._sum.totalKeys ?? 0
+    const totalMissKeys = sessionAgg._sum.missKeys ?? 0
+    const totalDurationMs = sessionAgg._sum.durationMs ?? 0
+    const totalSessions = sessionAgg._count.id
+
+    const totalMinutes = totalDurationMs / 60000
+    const averageWpm = totalMinutes > 0
+      ? Math.round(((totalKeys - totalMissKeys) / 5 / totalMinutes) * 100) / 100
+      : 0
+
+    const bestWpm = allSessions.reduce((max, s) => {
+      const mins = s.durationMs / 60000
+      const wpm = mins > 0 ? (s.totalKeys - s.missKeys) / 5 / mins : 0
+      return Math.max(max, wpm)
+    }, 0)
+
+    return {
+      totalKeys,
+      totalMissKeys,
+      totalDurationMs,
+      totalSessions,
+      averageWpm,
+      bestWpm: Math.round(bestWpm * 100) / 100,
+      uniqueWordCount: Number((uniqueWords[0] as { cnt: bigint }).cnt),
+      weakWordTotal: weakWordAgg._count.id,
+      weakWordSolved: solvedCount,
+    }
+  })
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { SentenceManager } from './components/SentenceManager/SentenceManager'
 import { PracticeScreen } from './components/PracticeScreen/PracticeScreen'
 import { HomeScreen } from './components/HomeScreen/HomeScreen'
 import { AnalysisScreen } from './components/AnalysisScreen/AnalysisScreen'
+import { StatsScreen } from './components/StatsScreen/StatsScreen'
 import type { SessionResult } from './hooks/useTypingSession'
 import { generateRandomText } from './utils/textGenerator'
 import { useAuthStore } from './stores/authStore'
@@ -411,6 +412,15 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
             onStartWordDrill={handleStartWordDrill}
             onStartFingeringSession={handleStartFingeringSession}
             isMockMode={isMockMode}
+            onLogout={handleLogout}
+            userName={user.name}
+          />
+        )}
+      />
+      <Route
+        path="/stats"
+        element={(
+          <StatsScreen
             onLogout={handleLogout}
             userName={user.name}
           />

--- a/frontend/src/components/Layout/DashboardLayout.tsx
+++ b/frontend/src/components/Layout/DashboardLayout.tsx
@@ -47,6 +47,9 @@ export function DashboardLayout({
                 <NavLink to="/library" className={navLinkClassName}>
                   ライブラリ
                 </NavLink>
+                <NavLink to="/stats" className={navLinkClassName}>
+                  統計
+                </NavLink>
               </nav>
             </div>
 

--- a/frontend/src/components/ResultsScreen/ResultsScreen.tsx
+++ b/frontend/src/components/ResultsScreen/ResultsScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { SessionResult } from '../../hooks/useTypingSession'
 import { formatWeaknessReason } from '../../lib/typingAnalysis'
+import { WpmDisplay } from '../ui/WpmDisplay'
 
 interface Props {
   mode: 'sentence' | 'random' | 'weak_word' | 'word_drill'
@@ -71,7 +72,12 @@ export function ResultsScreen({
             </div>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <Metric label="精度" value={`${accuracy}%`} color="text-emerald-600" />
-              <Metric label="WPM" value={String(wpm)} color="text-[#1d4ed8]" />
+              <div className="app-card-soft min-w-[120px] p-4 text-center">
+                <div className="text-3xl font-bold">
+                  <WpmDisplay wpm={wpm} />
+                </div>
+                <div className="mt-1 text-xs uppercase tracking-[0.16em] text-slate-400">WPM</div>
+              </div>
               <Metric label="タイム" value={`${seconds}s`} color="text-amber-600" />
               <Metric
                 label="ミス / 打鍵"

--- a/frontend/src/components/StatsScreen/StatsScreen.tsx
+++ b/frontend/src/components/StatsScreen/StatsScreen.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import { DashboardLayout } from '../Layout/DashboardLayout'
+import { WpmDisplay } from '../ui/WpmDisplay'
+import { fetchLifetimeStats } from '../../lib/stats'
+import type { LifetimeStats } from '../../lib/stats'
+
+interface Props {
+  onLogout: () => void
+  userName: string
+}
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${sec}s`
+  return `${sec}s`
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString()
+}
+
+interface StatCardProps {
+  label: string
+  children: ReactNode
+  description?: string
+}
+
+function StatCard({ label, children, description }: StatCardProps) {
+  return (
+    <div className="app-card-soft px-5 py-5">
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">{label}</p>
+      <div className="mt-2">{children}</div>
+      {description && <p className="mt-1 text-xs text-slate-400">{description}</p>}
+    </div>
+  )
+}
+
+export function StatsScreen({ onLogout, userName }: Props) {
+  const [stats, setStats] = useState<LifetimeStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchLifetimeStats()
+      .then(setStats)
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : '統計の取得に失敗しました'),
+      )
+      .finally(() => setLoading(false))
+  }, [])
+
+  const accuracy = stats && stats.totalKeys > 0
+    ? Math.round(((stats.totalKeys - stats.totalMissKeys) / stats.totalKeys) * 100)
+    : 0
+
+  return (
+    <DashboardLayout
+      title="生涯成績"
+      subtitle="これまでの全セッションの累計データです。"
+      userName={userName}
+      onLogout={onLogout}
+    >
+      {loading && (
+        <div className="flex items-center gap-3 py-6 text-sm text-slate-500">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-[#d6e3ed] border-t-[#3ea8ff]" />
+          読み込み中...
+        </div>
+      )}
+
+      {error && (
+        <div className="app-banner app-banner-danger">{error}</div>
+      )}
+
+      {!loading && !error && stats && stats.totalSessions === 0 && (
+        <div className="app-card-soft px-5 py-8 text-center text-sm text-slate-500">
+          まだセッションがありません。練習を始めると生涯成績が記録されます。
+        </div>
+      )}
+
+      {!loading && !error && stats && stats.totalSessions > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {/* 上段: 主要指標 */}
+          <StatCard label="総打鍵数">
+            <p className="text-3xl font-bold text-slate-900">{formatNumber(stats.totalKeys)}</p>
+          </StatCard>
+
+          <StatCard label="WPM 平均">
+            <WpmDisplay wpm={stats.averageWpm} intSize="text-3xl" decSize="text-xl" />
+          </StatCard>
+
+          <StatCard label="最高 WPM">
+            <WpmDisplay wpm={stats.bestWpm} intSize="text-3xl" decSize="text-xl" />
+          </StatCard>
+
+          <StatCard label="総正確率">
+            <p className="text-3xl font-bold text-emerald-600">{accuracy}%</p>
+          </StatCard>
+
+          {/* 下段: サブ指標 */}
+          <StatCard label="総セッション数">
+            <p className="text-3xl font-bold text-slate-900">
+              {formatNumber(stats.totalSessions)}
+              <span className="ml-1 text-lg font-semibold text-slate-400">回</span>
+            </p>
+          </StatCard>
+
+          <StatCard label="総練習時間">
+            <p className="text-3xl font-bold text-amber-600">{formatDuration(stats.totalDurationMs)}</p>
+          </StatCard>
+
+          <StatCard label="練習ユニーク単語数">
+            <p className="text-3xl font-bold text-slate-900">
+              {formatNumber(stats.uniqueWordCount)}
+              <span className="ml-1 text-lg font-semibold text-slate-400">語</span>
+            </p>
+          </StatCard>
+
+          <StatCard label="解決済み苦手ワード" description={`全 ${stats.weakWordTotal} 件中`}>
+            <p className="text-3xl font-bold text-rose-500">
+              {stats.weakWordSolved}
+              <span className="ml-1 text-lg font-semibold text-slate-400">/ {stats.weakWordTotal}</span>
+            </p>
+          </StatCard>
+        </div>
+      )}
+    </DashboardLayout>
+  )
+}

--- a/frontend/src/components/ui/WpmDisplay.tsx
+++ b/frontend/src/components/ui/WpmDisplay.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  wpm: number
+  className?: string
+  intSize?: string
+  decSize?: string
+}
+
+export function WpmDisplay({
+  wpm,
+  className = 'text-[#1d4ed8]',
+  intSize = 'text-3xl',
+  decSize = 'text-xl',
+}: Props) {
+  const fixed = wpm.toFixed(2)
+  const [intPart, decPart] = fixed.split('.')
+  return (
+    <span className={className}>
+      <span className={`font-bold ${intSize}`}>{intPart}</span>
+      <span className={`font-bold ${decSize} opacity-70`}>.{decPart}</span>
+    </span>
+  )
+}

--- a/frontend/src/lib/sessionText.test.ts
+++ b/frontend/src/lib/sessionText.test.ts
@@ -6,8 +6,8 @@ describe('normalizeSessionText', () => {
     expect(normalizeSessionText('alpha beta')).toBe('alpha beta ')
   })
 
-  it('preserves trailing periods for sentence-mode completion', () => {
-    expect(normalizeSessionText('alpha beta.')).toBe('alpha beta.')
+  it('still requires a trailing space after a period-final word', () => {
+    expect(normalizeSessionText('alpha beta.')).toBe('alpha beta. ')
   })
 })
 

--- a/frontend/src/lib/sessionText.ts
+++ b/frontend/src/lib/sessionText.ts
@@ -1,7 +1,8 @@
 export function normalizeSessionText(text: string): string {
   const trimmed = text.trim()
   if (!trimmed) return ''
-  return trimmed.endsWith('.') ? trimmed : `${trimmed} `
+  // Sessions always advance on a trailing separator, even after punctuation.
+  return `${trimmed} `
 }
 
 export function buildWeakWordPracticeTexts(words: string[], chunkSize = 5): string[] {

--- a/frontend/src/lib/stats.ts
+++ b/frontend/src/lib/stats.ts
@@ -1,0 +1,17 @@
+import { apiFetch } from './api'
+
+export interface LifetimeStats {
+  totalKeys: number
+  totalMissKeys: number
+  totalDurationMs: number
+  totalSessions: number
+  averageWpm: number
+  bestWpm: number
+  uniqueWordCount: number
+  weakWordTotal: number
+  weakWordSolved: number
+}
+
+export function fetchLifetimeStats(): Promise<LifetimeStats> {
+  return apiFetch<LifetimeStats>('/api/stats/lifetime')
+}

--- a/frontend/src/lib/typingAnalysis.test.ts
+++ b/frontend/src/lib/typingAnalysis.test.ts
@@ -114,6 +114,60 @@ describe('analyzeProblems', () => {
     })
     expect(result.wordStats[0].weaknessReasons).toEqual(['mistype'])
   })
+
+  it('excludes trailing periods from word aggregation', () => {
+    const result = analyzeProblems([
+      {
+        text: 'cat. ',
+        startedAt: 0,
+        endedAt: 350,
+        keyHistory: [
+          { key: 'c', correct: true, timestamp: 0, position: 0 },
+          { key: 'x', correct: false, timestamp: 100, position: 1 },
+          { key: 'a', correct: true, timestamp: 200, position: 1 },
+          { key: 't', correct: true, timestamp: 300, position: 2 },
+          { key: '.', correct: true, timestamp: 325, position: 3 },
+          { key: ' ', correct: true, timestamp: 350, position: 4 },
+        ],
+      },
+    ])
+
+    expect(result.wordStats).toHaveLength(1)
+    expect(result.wordStats[0]).toMatchObject({
+      word: 'cat',
+      totalChars: 3,
+      misses: 1,
+    })
+  })
+
+  it('does not count period-only misses as word misses', () => {
+    const result = analyzeProblems([
+      {
+        text: 'cat. ',
+        startedAt: 0,
+        endedAt: 250,
+        keyHistory: [
+          { key: 'c', correct: true, timestamp: 0, position: 0 },
+          { key: 'a', correct: true, timestamp: 50, position: 1 },
+          { key: 't', correct: true, timestamp: 100, position: 2 },
+          { key: ',', correct: false, timestamp: 150, position: 3 },
+          { key: '.', correct: true, timestamp: 200, position: 3 },
+          { key: ' ', correct: true, timestamp: 250, position: 4 },
+        ],
+      },
+    ])
+
+    expect(result.totalMisses).toBe(1)
+    expect(result.wordStats).toHaveLength(0)
+    expect(result.allWordMisses).toHaveLength(0)
+    expect(result.allWordStats).toEqual([
+      expect.objectContaining({
+        word: 'cat',
+        misses: 0,
+        totalChars: 3,
+      }),
+    ])
+  })
 })
 
 describe('getLiveTypingFeedback', () => {

--- a/frontend/src/lib/typingAnalysis.ts
+++ b/frontend/src/lib/typingAnalysis.ts
@@ -272,7 +272,7 @@ export function analyzeProblems(records: ProblemRecord[]): SessionResult {
   const accuracy = totalKeys > 0 ? Math.round(((totalKeys - totalMisses) / totalKeys) * 100) : 100
   const totalCorrectChars = records.reduce((sum, record) => sum + record.text.replace(/ $/, '').length, 0)
   const minutes = durationMs / 60000
-  const wpm = minutes > 0 ? Math.round(totalCorrectChars / 5 / minutes) : 0
+  const wpm = minutes > 0 ? totalCorrectChars / 5 / minutes : 0
 
   const allWordStats = [...wordMap.values()]
     .map(finalizeWordStat)

--- a/frontend/src/lib/typingAnalysis.ts
+++ b/frontend/src/lib/typingAnalysis.ts
@@ -54,8 +54,9 @@ export interface LiveTypingFeedback {
 }
 
 interface WordRange {
-  word: string
+  aggregateWord: string
   start: number
+  aggregateEnd: number
   end: number
 }
 
@@ -86,7 +87,14 @@ function splitIntoWords(text: string): WordRange[] {
   for (let i = 0; i <= text.length; i++) {
     if (i === text.length || text[i] === ' ') {
       if (i > start) {
-        result.push({ word: text.slice(start, i), start, end: i })
+        // Aggregate stats by lexical word only, excluding sentence-ending periods.
+        const aggregateWord = text.slice(start, i).replace(/\.+$/, '')
+        result.push({
+          aggregateWord,
+          start,
+          aggregateEnd: start + aggregateWord.length,
+          end: i,
+        })
       }
       start = i + 1
     }
@@ -98,7 +106,12 @@ function buildWordPositionMap(text: string, words: WordRange[]): Array<number | 
   const positionMap = Array<number | null>(text.length).fill(null)
 
   words.forEach((word, index) => {
-    for (let position = word.start; position < word.end; position += 1) {
+    if (!word.aggregateWord) {
+      return
+    }
+
+    // Map only the lexical word and its required trailing space; punctuation stays uncounted.
+    for (let position = word.start; position < word.aggregateEnd; position += 1) {
       positionMap[position] = index
     }
 
@@ -112,8 +125,8 @@ function buildWordPositionMap(text: string, words: WordRange[]): Array<number | 
 
 function createWordAggregate(word: WordRange): WordAggregate {
   return {
-    word: word.word,
-    totalChars: word.word.length,
+    word: word.aggregateWord,
+    totalChars: word.aggregateWord.length,
     misses: 0,
     activeDurationMs: 0,
     stallCount: 0,
@@ -232,11 +245,15 @@ export function analyzeProblems(records: ProblemRecord[]): SessionResult {
     const wordPositionMap = buildWordPositionMap(record.text, words)
 
     for (const word of words) {
-      const existing = wordMap.get(word.word)
+      if (!word.aggregateWord) {
+        continue
+      }
+
+      const existing = wordMap.get(word.aggregateWord)
       if (existing) {
-        existing.totalChars += word.word.length
+        existing.totalChars += word.aggregateWord.length
       } else {
-        wordMap.set(word.word, createWordAggregate(word))
+        wordMap.set(word.aggregateWord, createWordAggregate(word))
       }
     }
 
@@ -257,7 +274,7 @@ export function analyzeProblems(records: ProblemRecord[]): SessionResult {
       const wordIndex = getWordIndexAtPosition(wordPositionMap, event.position)
       if (wordIndex !== null && wordIndex !== undefined) {
         const word = words[wordIndex]
-        const aggregate = wordMap.get(word.word)
+        const aggregate = wordMap.get(word.aggregateWord)
         if (!aggregate) {
           continue
         }
@@ -332,6 +349,9 @@ export function getLiveTypingFeedback(params: {
   }
 
   const currentWord = words[currentWordIndex]
+  if (!currentWord.aggregateWord) {
+    return null
+  }
   const aggregate = createWordAggregate(currentWord)
   let previousTimestamp = startedAt
   let previousWasMiss = false


### PR DESCRIPTION
## Summary
- add backend and frontend support for lifetime statistics, including a dedicated stats screen
- improve results and dashboard UI with updated WPM display and navigation wiring
- fix period handling in typing analysis and refresh related tests
