### PR TITLE
feat: share practice sentences and add guest flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ DATABASE_URL=mysql://typing_user:strong-user-password@mysql:3306/typing_en
 PORT=3000
 # フロントエンドの公開 URL（CORS 設定に使用）
 FRONTEND_URL=https://your-domain.com
+# 共有問題を管理できる Gmail アドレス（カンマ区切り）
+ADMIN_GOOGLE_EMAILS=admin1@gmail.com,admin2@gmail.com
 
 # ---- Cloudflare Tunnel ----
 # Zero Trust ダッシュボード → Tunnels でトークンを取得

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@
 
 ## 主な特徴
 
-- **文章・単語練習** — 登録した文章を基本単位として練習。カテゴリ単位の出題や記号・数字・ランダム英数字にも対応
+- **登録不要の通常練習** — 共有の練習問題から 5 問をすぐに開始。初見ユーザーでもそのまま試せます
+- **共有問題 + 管理者運用** — 練習文章は全員共通。管理は `.env` で許可した Gmail のみが行えます
 - **苦手ワード自動検出** — 練習中にミス率が高かった単語を自動検出し、苦手ワードリストへ追加
 - **苦手ワード集中練習モード** — 苦手リストの単語を繰り返し練習して克服
 - **Bigram（運指ペア）分析** — "w→a" のような連続2打鍵ペアごとにミス率を集計し、苦手な指の動きを特定
 - **リアルタイム入力履歴** — 練習中、格闘ゲームのコマンド履歴のように打鍵履歴をリアルタイム表示
-- **攻略メモ / カテゴリ** — 文章・苦手ワードごとに運指のコツなどを自由記述で保存し、文章には複数カテゴリも付与可能
-- **CSV インポート** — 練習したい文章をCSVで一括登録。ファイル名カテゴリも自動付与
-- **Google アカウント認証** — ログインにより統計・練習データをユーザーごとに保存（未ログイン時は保存不可）
+- **攻略メモ / カテゴリ** — 管理者は共有文章にメモやカテゴリを付けて整理できます
+- **CSV インポート** — 管理者は CSV で共有問題を一括登録できます
+- **Google アカウント認証** — ログインにより統計・苦手分析・設定をユーザーごとに保存できます
 
 ---
 
@@ -38,6 +39,7 @@ cp .env.example .env
 #   GOOGLE_CLIENT_SECRET=...
 #   JWT_SECRET=...
 #   MYSQL_ROOT_PASSWORD=...
+#   ADMIN_GOOGLE_EMAILS=admin1@gmail.com,admin2@gmail.com
 
 # 3. 起動
 docker compose up -d
@@ -145,7 +147,7 @@ text,note,categories
 - `note`（任意）: 攻略メモ
 - `category` / `categories`（任意）: カンマ区切りのカテゴリ
 - CSVファイル名（拡張子除く）は自動でカテゴリとして付与
-- 同一ユーザー・同一テキストの重複は無視されます
+- 同一テキストの重複は無視されます
 - `word-csv/` にはスターター用CSVを同梱しており、`tricky-long-sentences.csv` と `lookalike-confusion.csv` はタイピングゲーム向けの誤打しやすい文章セットです
 
 ---
@@ -156,9 +158,10 @@ text,note,categories
 GET    /auth/google              Google OAuth ログイン開始
 GET    /auth/me                  ログインユーザー情報
 
-GET    /api/sentences            文章一覧
-POST   /api/sentences            文章登録
-POST   /api/sentences/import     CSV一括インポート
+GET    /api/public/sentences     公開用の練習問題を取得
+GET    /api/sentences            文章一覧（管理者）
+POST   /api/sentences            文章登録（管理者）
+POST   /api/sentences/import     CSV一括インポート（管理者）
 
 GET    /api/weak-words           苦手ワード一覧
 PATCH  /api/weak-words/:id       攻略メモ更新

--- a/backend/prisma/migrations/20260414164500_share_sentences_globally/migration.sql
+++ b/backend/prisma/migrations/20260414164500_share_sentences_globally/migration.sql
@@ -1,0 +1,46 @@
+CREATE TEMPORARY TABLE `SentenceCanonical` AS
+SELECT MIN(`id`) AS `canonicalId`, `text`
+FROM `Sentence`
+GROUP BY `text`;
+
+INSERT INTO `SentenceCategory` (`id`, `sentenceId`, `category`)
+SELECT
+    REPLACE(UUID(), '-', ''),
+    canonical.`canonicalId`,
+    category.`category`
+FROM `SentenceCategory` category
+INNER JOIN `Sentence` sentence ON sentence.`id` = category.`sentenceId`
+INNER JOIN `SentenceCanonical` canonical ON canonical.`text` = sentence.`text`
+LEFT JOIN `SentenceCategory` existing
+    ON existing.`sentenceId` = canonical.`canonicalId`
+   AND existing.`category` = category.`category`
+WHERE existing.`id` IS NULL;
+
+UPDATE `SessionSentence` sessionSentence
+INNER JOIN `Sentence` sentence ON sentence.`id` = sessionSentence.`sentenceId`
+INNER JOIN `SentenceCanonical` canonical ON canonical.`text` = sentence.`text`
+SET sessionSentence.`sentenceId` = canonical.`canonicalId`
+WHERE sessionSentence.`sentenceId` <> canonical.`canonicalId`;
+
+DELETE sentence
+FROM `Sentence` sentence
+INNER JOIN `SentenceCanonical` canonical ON canonical.`text` = sentence.`text`
+WHERE sentence.`id` <> canonical.`canonicalId`;
+
+ALTER TABLE `Sentence` DROP FOREIGN KEY `Sentence_userId_fkey`;
+
+ALTER TABLE `Sentence`
+    CHANGE COLUMN `userId` `createdByUserId` VARCHAR(191) NULL;
+
+DROP INDEX `Sentence_userId_text_key` ON `Sentence`;
+
+CREATE INDEX `Sentence_createdByUserId_idx` ON `Sentence`(`createdByUserId`);
+CREATE UNIQUE INDEX `Sentence_text_key` ON `Sentence`(`text`(500));
+
+ALTER TABLE `Sentence`
+    ADD CONSTRAINT `Sentence_createdByUserId_fkey`
+    FOREIGN KEY (`createdByUserId`) REFERENCES `User`(`id`)
+    ON DELETE SET NULL
+    ON UPDATE CASCADE;
+
+DROP TEMPORARY TABLE `SentenceCanonical`;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,7 +13,7 @@ model User {
   email       String        @unique
   name        String
   createdAt   DateTime      @default(now())
-  sentences   Sentence[]
+  createdSentences Sentence[] @relation("SentenceCreator")
   weakWords   WeakWord[]
   sessions    Session[]
   bigramStats BigramStat[]
@@ -21,16 +21,17 @@ model User {
 }
 
 model Sentence {
-  id           String           @id @default(cuid())
-  userId       String
-  text         String           @db.Text
-  note         String?          @db.Text
-  createdAt    DateTime         @default(now())
-  user         User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-  categories   SentenceCategory[]
-  sessionLinks SessionSentence[]
+  id              String           @id @default(cuid())
+  createdByUserId String?
+  text            String           @db.Text
+  note            String?          @db.Text
+  createdAt       DateTime         @default(now())
+  createdBy       User?            @relation("SentenceCreator", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  categories      SentenceCategory[]
+  sessionLinks    SessionSentence[]
 
-  @@unique([userId, text(length: 500)])
+  @@unique([text(length: 500)])
+  @@index([createdByUserId])
 }
 
 model SentenceCategory {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -32,6 +32,7 @@ app.get('/health', async () => ({ status: 'ok' }))
 
 // Routes
 await app.register(import('./routes/auth.js'))
+await app.register(import('./routes/publicSentences.js'), { prefix: '/api' })
 await app.register(import('./routes/sentences.js'), { prefix: '/api' })
 await app.register(import('./routes/weakWords.js'), { prefix: '/api' })
 await app.register(import('./routes/bigramStats.js'), { prefix: '/api' })

--- a/backend/src/lib/admin.ts
+++ b/backend/src/lib/admin.ts
@@ -1,0 +1,27 @@
+const ADMIN_EMAIL_SPLIT_PATTERN = /[\s,]+/
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+export function getAdminEmails(): Set<string> {
+  const raw = process.env.ADMIN_GOOGLE_EMAILS ?? ''
+  const emails = raw
+    .split(ADMIN_EMAIL_SPLIT_PATTERN)
+    .map(normalizeEmail)
+    .filter(Boolean)
+
+  return new Set(emails)
+}
+
+export function isAdminEmail(email: string | null | undefined): boolean {
+  if (!email) {
+    return false
+  }
+
+  if (process.env.AUTH_MOCK === 'true' && normalizeEmail(email) === 'mock@example.com') {
+    return true
+  }
+
+  return getAdminEmails().has(normalizeEmail(email))
+}

--- a/backend/src/middleware/requireAdmin.ts
+++ b/backend/src/middleware/requireAdmin.ts
@@ -1,0 +1,11 @@
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { isAdminEmail } from '../lib/admin.js'
+
+export async function requireAdmin(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  if (!req.user || !isAdminEmail(req.user.email)) {
+    return reply.status(403).send({ message: 'Forbidden' })
+  }
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20'
 import jwt from 'jsonwebtoken'
 import { prisma } from '../db.js'
+import { isAdminEmail } from '../lib/admin.js'
 import { authenticateJWT } from '../middleware/authenticate.js'
 import { passport } from '../passport.js'
 
@@ -78,7 +79,7 @@ export default async function authRoutes(app: FastifyInstance) {
     { preHandler: [authenticateJWT] },
     async (req) => {
       const { id, email, name, createdAt } = req.user!
-      return { id, email, name, createdAt }
+      return { id, email, name, createdAt, isAdmin: isAdminEmail(email) }
     },
   )
 

--- a/backend/src/routes/bigramStats.ts
+++ b/backend/src/routes/bigramStats.ts
@@ -31,7 +31,7 @@ export default async function bigramStatRoutes(app: FastifyInstance) {
   })
 
   // GET /api/bigram-stats/words?bigrams=wa,t%20,%20r
-  // 指定バイグラムを含む単語をユーザーの文章コーパスから抽出して返す。
+  // 指定バイグラムを含む単語を共有の文章コーパスから抽出して返す。
   //
   // バイグラムのマッチング規則:
   //   □→X (" X"): X で始まる単語  例: " r" → "run", "red"
@@ -40,7 +40,6 @@ export default async function bigramStatRoutes(app: FastifyInstance) {
   //
   // スペースを含むバイグラムは単語境界の遷移を表すため、trim() せずに保持する。
   app.get('/bigram-stats/words', { preHandler: [authenticateJWT] }, async (req, reply) => {
-    const userId = req.user!.id
     const query = (req.query as { bigrams?: string }).bigrams ?? ''
     // trim() しない — スペースを含むバイグラム ("t ", " r") を保持する
     const bigrams = query
@@ -53,7 +52,6 @@ export default async function bigramStatRoutes(app: FastifyInstance) {
     }
 
     const sentences = await prisma.sentence.findMany({
-      where: { userId },
       select: { text: true },
     })
 

--- a/backend/src/routes/publicSentences.ts
+++ b/backend/src/routes/publicSentences.ts
@@ -1,0 +1,66 @@
+import type { FastifyInstance } from 'fastify'
+import { prisma } from '../db.js'
+
+const DEFAULT_PUBLIC_SESSION_COUNT = 5
+const MAX_PUBLIC_SESSION_COUNT = 20
+
+function shuffle<T>(items: T[]): T[] {
+  const shuffled = [...items]
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1))
+    ;[shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]]
+  }
+  return shuffled
+}
+
+function parseCount(value: unknown): number | null {
+  if (value === undefined) {
+    return DEFAULT_PUBLIC_SESSION_COUNT
+  }
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null
+  }
+
+  const count = Number(value)
+  if (!Number.isInteger(count) || count <= 0 || count > MAX_PUBLIC_SESSION_COUNT) {
+    return null
+  }
+
+  return count
+}
+
+export default async function publicSentenceRoutes(app: FastifyInstance) {
+  app.get('/public/sentences', async (req, reply) => {
+    const count = parseCount((req.query as { count?: unknown }).count)
+    if (count === null) {
+      return reply.status(400).send({
+        message: `count must be an integer between 1 and ${MAX_PUBLIC_SESSION_COUNT}`,
+      })
+    }
+
+    const sentences = await prisma.sentence.findMany({
+      select: {
+        id: true,
+        text: true,
+        createdAt: true,
+      },
+    })
+
+    if (sentences.length === 0) {
+      return reply.status(503).send({ message: '公開練習用の文章がまだありません' })
+    }
+
+    const selected = shuffle(sentences).slice(0, Math.min(count, sentences.length))
+
+    return {
+      sentences: selected.map((sentence) => ({
+        id: sentence.id,
+        text: sentence.text,
+        note: null,
+        createdAt: sentence.createdAt,
+        categories: [] as string[],
+      })),
+      total: sentences.length,
+    }
+  })
+}

--- a/backend/src/routes/sentences.ts
+++ b/backend/src/routes/sentences.ts
@@ -4,6 +4,7 @@ import { parse } from 'csv-parse'
 import { basename, extname } from 'node:path'
 import { prisma } from '../db.js'
 import { authenticateJWT } from '../middleware/authenticate.js'
+import { requireAdmin } from '../middleware/requireAdmin.js'
 
 const MAX_TEXT_LENGTH = 5000
 const MAX_CATEGORY_COUNT = 20
@@ -73,17 +74,15 @@ export default async function sentenceRoutes(app: FastifyInstance) {
   // GET /api/sentences — list user's sentences
   app.get(
     '/sentences',
-    { preHandler: [authenticateJWT] },
-    async (req) => {
-      const userId = req.user!.id
+    { preHandler: [authenticateJWT, requireAdmin] },
+    async () => {
       const [sentences, total] = await Promise.all([
         prisma.sentence.findMany({
-          where: { userId },
           orderBy: { createdAt: 'desc' },
           take: 200,
           select: sentenceSelect,
         }),
-        prisma.sentence.count({ where: { userId } }),
+        prisma.sentence.count(),
       ])
       return { sentences: sentences.map(mapSentence), total }
     },
@@ -92,9 +91,9 @@ export default async function sentenceRoutes(app: FastifyInstance) {
   // POST /api/sentences/import — CSV bulk import (must be before /:id)
   app.post(
     '/sentences/import',
-    { preHandler: [authenticateJWT] },
+    { preHandler: [authenticateJWT, requireAdmin] },
     async (req, reply) => {
-      const userId = req.user!.id
+      const createdByUserId = req.user!.id
       const data = await req.file()
       if (!data) {
         return reply.status(400).send({ message: 'No file uploaded' })
@@ -124,7 +123,7 @@ export default async function sentenceRoutes(app: FastifyInstance) {
         try {
           await prisma.sentence.create({
             data: {
-              userId,
+              createdByUserId,
               text,
               note: row['note'] || null,
               ...(categories.length > 0
@@ -154,9 +153,9 @@ export default async function sentenceRoutes(app: FastifyInstance) {
   // POST /api/sentences — create single sentence
   app.post(
     '/sentences',
-    { preHandler: [authenticateJWT] },
+    { preHandler: [authenticateJWT, requireAdmin] },
     async (req, reply) => {
-      const userId = req.user!.id
+      const createdByUserId = req.user!.id
       const { text, note, categories } = req.body as {
         text?: string
         note?: string
@@ -182,7 +181,7 @@ export default async function sentenceRoutes(app: FastifyInstance) {
       try {
         const sentence = await prisma.sentence.create({
           data: {
-            userId,
+            createdByUserId,
             text: trimmed,
             note: note?.trim() || null,
             ...(normalizedCategories.length > 0
@@ -209,9 +208,8 @@ export default async function sentenceRoutes(app: FastifyInstance) {
   // PATCH /api/sentences/:id — update text or note
   app.patch(
     '/sentences/:id',
-    { preHandler: [authenticateJWT] },
+    { preHandler: [authenticateJWT, requireAdmin] },
     async (req, reply) => {
-      const userId = req.user!.id
       const { id } = req.params as { id: string }
       const { text, note, categories } = req.body as {
         text?: string
@@ -221,9 +219,9 @@ export default async function sentenceRoutes(app: FastifyInstance) {
 
       const existing = await prisma.sentence.findUnique({
         where: { id },
-        select: { userId: true },
+        select: { id: true },
       })
-      if (!existing || existing.userId !== userId) {
+      if (!existing) {
         return reply.status(404).send({ message: 'Not found' })
       }
       if (categories !== undefined && !Array.isArray(categories)) {
@@ -281,16 +279,15 @@ export default async function sentenceRoutes(app: FastifyInstance) {
   // DELETE /api/sentences/:id
   app.delete(
     '/sentences/:id',
-    { preHandler: [authenticateJWT] },
+    { preHandler: [authenticateJWT, requireAdmin] },
     async (req, reply) => {
-      const userId = req.user!.id
       const { id } = req.params as { id: string }
 
       const existing = await prisma.sentence.findUnique({
         where: { id },
-        select: { userId: true },
+        select: { id: true },
       })
-      if (!existing || existing.userId !== userId) {
+      if (!existing) {
         return reply.status(404).send({ message: 'Not found' })
       }
 

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -157,15 +157,12 @@ export default async function sessionRoutes(app: FastifyInstance) {
     const uniqueSentenceIds = [...new Set(sentenceIds)]
     if (uniqueSentenceIds.length > 0) {
       const sentences = await prisma.sentence.findMany({
-        where: {
-          userId,
-          id: { in: uniqueSentenceIds },
-        },
+        where: { id: { in: uniqueSentenceIds } },
         select: { id: true },
       })
 
       if (sentences.length !== uniqueSentenceIds.length) {
-        return sendBadRequest(reply, 'sentenceIds contain unknown or unauthorized sentences')
+        return sendBadRequest(reply, 'sentenceIds contain unknown sentences')
       }
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import { AnalysisScreen } from './components/AnalysisScreen/AnalysisScreen'
 import { StatsScreen } from './components/StatsScreen/StatsScreen'
 import { SettingsScreen } from './components/SettingsScreen/SettingsScreen'
 import type { SessionResult } from './hooks/useTypingSession'
-import { generateRandomText } from './utils/textGenerator'
 import { useAuthStore } from './stores/authStore'
 import { apiFetch } from './lib/api'
 import { normalizeSessionText, buildWeakWordPracticeTexts } from './lib/sessionText'
@@ -23,6 +22,7 @@ import { saveSession } from './lib/sessions'
 import type { Sentence } from './lib/sentences'
 import { listWeakWords } from './lib/weakWords'
 import { listWeakBigrams, fetchWordsForBigrams } from './lib/bigramStats'
+import { fetchPublicPracticeSentences } from './lib/publicSentences'
 import { pickSessionSentences } from './lib/sentenceCategories'
 
 type SessionMode = 'sentence' | 'random' | 'weak_word' | 'word_drill'
@@ -53,7 +53,7 @@ function normalizeText(text: string): string {
   return normalizeSessionText(text)
 }
 
-const RANDOM_TEXT_LENGTH = 30
+const DEFAULT_PUBLIC_SESSION_COUNT = 5
 const MAX_WEAK_WORD_QUESTIONS = 10
 
 function createWordDrillItems(word: string, count: number): SessionText[] {
@@ -64,16 +64,9 @@ function createWordDrillItems(word: string, count: number): SessionText[] {
   }))
 }
 
-function generateRandomSessionItems(): SessionText[] {
-  return [{
-    text: generateRandomText(RANDOM_TEXT_LENGTH, 'full'),
-    sentenceId: null,
-  }]
-}
-
 function shuffleArray<T>(arr: T[]): T[] {
   const result = [...arr]
-  for (let i = result.length - 1; i > 0; i--) {
+  for (let i = result.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1))
     ;[result[i], result[j]] = [result[j], result[i]]
   }
@@ -92,6 +85,7 @@ interface AuthMe {
   name: string
   email: string
   createdAt: string
+  isAdmin: boolean
 }
 
 export default function App() {
@@ -102,7 +96,7 @@ export default function App() {
 
   useEffect(() => {
     if (isMockMode) {
-      setAuth({ id: 'mock-user', name: 'Mock User', email: 'mock@example.com' }, 'mock-token')
+      setAuth({ id: 'mock-user', name: 'Mock User', email: 'mock@example.com', isAdmin: true }, 'mock-token')
       setAuthLoaded(true)
       return
     }
@@ -125,7 +119,6 @@ export default function App() {
       return
     }
 
-    // Store the callback token before fetching /auth/me
     if (callbackToken) {
       localStorage.setItem('token', callbackToken)
     }
@@ -133,7 +126,7 @@ export default function App() {
     apiFetch<AuthMe>('/auth/me')
       .then((me) => {
         setAuthError(false)
-        setAuth({ id: me.id, name: me.name, email: me.email }, activeToken)
+        setAuth({ id: me.id, name: me.name, email: me.email, isAdmin: me.isAdmin }, activeToken)
         if (callbackToken) {
           window.history.replaceState(null, '', window.location.pathname)
         }
@@ -172,7 +165,7 @@ export default function App() {
 }
 
 interface AppRouterProps {
-  user: { id: string; name: string; email: string } | null
+  user: { id: string; name: string; email: string; isAdmin: boolean } | null
   token: string | null
   authError: boolean
   isMockMode: boolean
@@ -209,6 +202,24 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
     })
   }, [beginSession])
 
+  const handleStartPublicPracticeSession = useCallback(async () => {
+    await pendingSaveRef.current
+
+    const { sentences } = await fetchPublicPracticeSentences(DEFAULT_PUBLIC_SESSION_COUNT)
+    if (sentences.length === 0) {
+      throw new Error('公開練習に使える文章がまだありません')
+    }
+
+    beginSession({
+      mode: 'sentence',
+      items: mapSentencesToSessionItems(sentences),
+      returnPath: '/',
+      sourceSentences: sentences,
+      sessionCount: sentences.length,
+      sessionCategories: [],
+    })
+  }, [beginSession])
+
   const handleStartWeakWordSession = useCallback(async () => {
     await pendingSaveRef.current
 
@@ -238,9 +249,6 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
     })
   }, [beginSession, isMockMode, token])
 
-  // 苦手運指練習セッションを開始する。
-  // ミス率上位 10 バイグラムを取得し、それらを含む単語を文章コーパスから抽出して練習テキストを構築する。
-  // セッション保存は weak_word モードと同じ経路を通るため、ミスした単語は苦手ワードにも自動登録される。
   const handleStartFingeringSession = useCallback(async () => {
     await pendingSaveRef.current
 
@@ -257,12 +265,11 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
       throw new Error('まだ十分な運指データがありません。通常練習を行うとデータが蓄積されます。')
     }
 
-    const { words } = await fetchWordsForBigrams(topBigrams.map((b) => b.bigram))
+    const { words } = await fetchWordsForBigrams(topBigrams.map((bigram) => bigram.bigram))
     if (words.length < 3) {
-      throw new Error(`対象の運指パターンを含む単語が少なすぎます（${words.length}件）。文章管理でより多くの文章を追加してください。`)
+      throw new Error(`対象の運指パターンを含む単語が少なすぎます（${words.length}件）。共有問題を増やしてからお試しください。`)
     }
 
-    // シャッフルして最大 MAX_WEAK_WORD_QUESTIONS チャンク分の単語を使用する
     const shuffled = shuffleArray(words).slice(0, MAX_WEAK_WORD_QUESTIONS * 5)
     const texts = buildWeakWordPracticeTexts(shuffled).slice(0, MAX_WEAK_WORD_QUESTIONS)
 
@@ -273,14 +280,6 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
       isFingering: true,
     })
   }, [beginSession, isMockMode, token])
-
-  const handleStartRandomSession = useCallback(() => {
-    beginSession({
-      mode: 'random',
-      items: generateRandomSessionItems(),
-      returnPath: '/',
-    })
-  }, [beginSession])
 
   const handleStartWordDrill = useCallback((word: string, count: number) => {
     beginSession({
@@ -373,15 +372,8 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
       return
     }
 
-    const nextConfig = lastSessionConfig.mode === 'random'
-      ? {
-          ...lastSessionConfig,
-          items: generateRandomSessionItems(),
-        }
-      : lastSessionConfig
-
-    setActiveSession(nextConfig)
-    setLastSessionConfig(nextConfig)
+    setActiveSession(lastSessionConfig)
+    setLastSessionConfig(lastSessionConfig)
     setResultsState(null)
     navigate('/practice')
   }, [handleStartFingeringSession, handleStartWeakWordSession, lastSessionConfig, navigate])
@@ -398,45 +390,42 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
     navigate('/login', { replace: true })
   }, [navigate, onLogout])
 
-  if (!user) {
-    return (
-      <Routes>
-        <Route path="/login" element={<LoginScreen error={authError} />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
-      </Routes>
-    )
-  }
-
   return (
     <Routes>
       <Route
         path="/"
         element={(
           <HomeScreen
-            onStartRandomSession={handleStartRandomSession}
-            onStartSentenceSession={handleStartSentenceSession}
+            onStartPracticeSession={handleStartPublicPracticeSession}
             onStartWeakWordSession={handleStartWeakWordSession}
             onStartFingeringSession={handleStartFingeringSession}
             isMockMode={isMockMode}
-            onLogout={handleLogout}
-            userName={user.name}
+            isAuthenticated={Boolean(user)}
+            isAdmin={Boolean(user?.isAdmin)}
+            onLogout={user ? handleLogout : undefined}
+            userName={user?.name}
           />
         )}
       />
-      <Route path="/login" element={<Navigate to="/" replace />} />
+      <Route
+        path="/login"
+        element={user ? <Navigate to="/" replace /> : <LoginScreen error={authError} />}
+      />
       <Route
         path="/library"
-        element={(
+        element={user?.isAdmin ? (
           <SentenceManager
             onStartSession={handleStartSentenceSession}
             onLogout={handleLogout}
             userName={user.name}
           />
+        ) : (
+          <Navigate to={user ? '/' : '/login'} replace />
         )}
       />
       <Route
         path="/analysis"
-        element={(
+        element={user ? (
           <AnalysisScreen
             onStartWeakWordSession={handleStartWeakWordSession}
             onStartWordDrill={handleStartWordDrill}
@@ -445,27 +434,32 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
             onLogout={handleLogout}
             userName={user.name}
           />
+        ) : (
+          <Navigate to="/login" replace />
         )}
       />
       <Route
         path="/stats"
-        element={(
+        element={user ? (
           <StatsScreen
             onLogout={handleLogout}
             userName={user.name}
           />
+        ) : (
+          <Navigate to="/login" replace />
         )}
       />
       <Route
         path="/settings"
-        element={(
+        element={user ? (
           <SettingsScreen
             onLogout={handleLogout}
             userName={user.name}
           />
+        ) : (
+          <Navigate to="/login" replace />
         )}
       />
-      {/* 旧URLの後方互換リダイレクト */}
       <Route path="/sentences" element={<Navigate to="/library" replace />} />
       <Route path="/weak-words" element={<Navigate to="/analysis" replace />} />
       <Route path="/fingering" element={<Navigate to="/analysis" replace />} />
@@ -477,7 +471,8 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
             sessionItems={activeSession.items}
             onComplete={handleSessionComplete}
             onAbort={handleAbortSession}
-            onLogout={handleLogout}
+            onLogout={user ? handleLogout : undefined}
+            canUseSavedSettings={Boolean(user && token)}
             returnPath={activeSession.returnPath}
           />
         ) : resultsState ? (
@@ -495,6 +490,7 @@ function AppRouter({ user, token, authError, isMockMode, onLogout }: AppRouterPr
             totalCount={resultsState.totalCount}
             onRestart={handleRestartSession}
             onStartWeakWordSession={handleStartWeakWordSession}
+            canStartWeakWordSession={Boolean(user)}
             isMockMode={isMockMode}
             onGoBack={handleGoBackFromResults}
             returnLabel={

--- a/frontend/src/components/HomeScreen/HomeScreen.tsx
+++ b/frontend/src/components/HomeScreen/HomeScreen.tsx
@@ -1,62 +1,73 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { DashboardLayout } from '../Layout/DashboardLayout'
-import { StartSessionModal } from '../SentenceManager/StartSessionModal'
-import { useSentenceStore } from '../../stores/sentenceStore'
 import { listWeakWords } from '../../lib/weakWords'
 import { listWeakBigrams } from '../../lib/bigramStats'
-import type { Sentence } from '../../lib/sentences'
 
 interface Props {
-  onStartRandomSession: () => void
-  onStartSentenceSession: (
-    selectedSentences: Sentence[],
-    sourceSentences: Sentence[],
-    count: number,
-    categories: string[],
-  ) => void
+  onStartPracticeSession: () => Promise<void>
   onStartWeakWordSession: () => Promise<void>
   onStartFingeringSession: () => Promise<void>
   isMockMode: boolean
-  onLogout: () => void
-  userName: string
+  isAuthenticated: boolean
+  isAdmin: boolean
+  onLogout?: () => void
+  userName?: string
 }
 
 export function HomeScreen({
-  onStartRandomSession,
-  onStartSentenceSession,
+  onStartPracticeSession,
   onStartWeakWordSession,
   onStartFingeringSession,
   isMockMode,
+  isAuthenticated,
+  isAdmin,
   onLogout,
   userName,
 }: Props) {
-  const { sentences, total, fetchSentences } = useSentenceStore()
   const [weakWordCount, setWeakWordCount] = useState<number | null>(null)
   const [bigramCount, setBigramCount] = useState<number | null>(null)
-  const [showSentenceModal, setShowSentenceModal] = useState(false)
+  const [practiceError, setPracticeError] = useState<string | null>(null)
   const [weakWordError, setWeakWordError] = useState<string | null>(null)
   const [fingeringError, setFingeringError] = useState<string | null>(null)
+  const [startingPractice, setStartingPractice] = useState(false)
   const [startingWeak, setStartingWeak] = useState(false)
   const [startingFingering, setStartingFingering] = useState(false)
 
   useEffect(() => {
-    void fetchSentences()
-  }, [fetchSentences])
+    if (!isAuthenticated || isMockMode) {
+      setWeakWordCount(null)
+      setBigramCount(null)
+      return
+    }
 
-  useEffect(() => {
-    if (isMockMode) return
     listWeakWords()
       .then(({ words }) => {
-        setWeakWordCount(words.filter((w) => !w.isSolved).length)
+        setWeakWordCount(words.filter((word) => !word.isSolved).length)
       })
-      .catch(() => { /* count stays null */ })
+      .catch(() => {
+        setWeakWordCount(null)
+      })
+
     listWeakBigrams()
       .then(({ bigrams }) => {
         setBigramCount(bigrams.length)
       })
-      .catch(() => { /* count stays null */ })
-  }, [isMockMode])
+      .catch(() => {
+        setBigramCount(null)
+      })
+  }, [isAuthenticated, isMockMode])
+
+  const handlePracticeClick = async () => {
+    setStartingPractice(true)
+    setPracticeError(null)
+    try {
+      await onStartPracticeSession()
+    } catch (err) {
+      setPracticeError(err instanceof Error ? err.message : '通常練習を開始できませんでした')
+      setStartingPractice(false)
+    }
+  }
 
   const handleWeakWordClick = async () => {
     setStartingWeak(true)
@@ -83,64 +94,41 @@ export function HomeScreen({
   return (
     <DashboardLayout
       title="今すぐ練習する"
-      subtitle="モードを選んでスタート"
+      subtitle={isAuthenticated ? '共有の練習問題からすぐに始められます。' : 'ログインなしで通常練習 5 問を始められます。'}
       userName={userName}
+      isAuthenticated={isAuthenticated}
+      isAdmin={isAdmin}
       onLogout={onLogout}
     >
       <div className="space-y-4">
-        {/* Hero CTA: Random */}
         <div className="rounded-2xl border border-[#3ea8ff]/30 bg-[#eff6ff] px-6 py-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-semibold text-[#1d4ed8]">登録不要 · 今すぐスタート</p>
-              <p className="mt-1 text-xl font-bold text-slate-900">ランダムワード練習</p>
-              <p className="mt-1 text-sm text-slate-500">30語をランダム生成して即スタート。セットアップ不要。</p>
-            </div>
-            <button
-              onClick={onStartRandomSession}
-              className="app-button app-button-primary min-h-[52px] shrink-0 px-8 text-base"
-            >
-              今すぐ開始
-            </button>
-          </div>
-        </div>
-
-        {/* Secondary modes grid */}
-        <div className="grid gap-4 lg:grid-cols-3">
-          {/* Sentence library */}
-          <div className="app-card-soft flex flex-col gap-4 px-5 py-5">
-            <div>
-              <p className="text-sm font-semibold text-slate-900">文章ライブラリ練習</p>
-              <p className="mt-1 text-sm text-slate-500">登録した文章からランダム出題します。</p>
-              <p className="mt-2 text-2xl font-bold text-slate-900">
-                {total}
-                <span className="ml-1 text-sm font-normal text-slate-400">件登録済み</span>
+              <p className="mt-1 text-xl font-bold text-slate-900">通常練習 5 問</p>
+              <p className="mt-1 text-sm text-slate-500">
+                共有の練習問題から 5 問を出題します。{isAuthenticated ? 'ログイン中なら結果も保存できます。' : 'まずはログインなしで試せます。'}
               </p>
             </div>
-            <div className="mt-auto space-y-2">
-              <button
-                onClick={() => setShowSentenceModal(true)}
-                disabled={sentences.length === 0}
-                className="app-button app-button-secondary w-full"
-                title={sentences.length === 0 ? 'まずライブラリに文章を追加してください' : undefined}
-              >
-                練習開始
-              </button>
-              <Link
-                to="/library"
-                className="block text-center text-xs text-[#3ea8ff] hover:text-[#0f83fd]"
-              >
-                ライブラリを管理 →
-              </Link>
-            </div>
+            <button
+              onClick={() => void handlePracticeClick()}
+              disabled={startingPractice}
+              className="app-button app-button-primary min-h-[52px] shrink-0 px-8 text-base"
+            >
+              {startingPractice ? '準備中...' : '今すぐ開始'}
+            </button>
           </div>
+          {practiceError && (
+            <p className="mt-3 text-sm text-rose-600">{practiceError}</p>
+          )}
+        </div>
 
-          {/* Weak words */}
+        <div className="grid gap-4 lg:grid-cols-3">
           <div className="app-card-soft flex flex-col gap-4 px-5 py-5">
             <div>
               <p className="text-sm font-semibold text-slate-900">苦手ワード練習</p>
               <p className="mt-1 text-sm text-slate-500">ミスの多い単語を集中的に練習します。</p>
-              {!isMockMode && weakWordCount !== null && (
+              {isAuthenticated && !isMockMode && weakWordCount !== null && (
                 <p className="mt-2 text-2xl font-bold text-slate-900">
                   {weakWordCount}
                   <span className="ml-1 text-sm font-normal text-slate-400">件 未攻略</span>
@@ -153,30 +141,33 @@ export function HomeScreen({
             <div className="mt-auto space-y-2">
               <button
                 onClick={() => void handleWeakWordClick()}
-                disabled={isMockMode || startingWeak}
+                disabled={!isAuthenticated || isMockMode || startingWeak}
                 className="app-button app-button-secondary w-full"
-                title={isMockMode ? 'モック認証では利用できません' : undefined}
+                title={!isAuthenticated ? 'ログインすると利用できます' : isMockMode ? 'モック認証では利用できません' : undefined}
               >
                 {startingWeak && (
                   <span className="h-4 w-4 animate-spin rounded-full border-2 border-[#3ea8ff]/40 border-t-[#3ea8ff]" />
                 )}
                 練習開始
               </button>
-              <Link
-                to="/analysis"
-                className="block text-center text-xs text-[#3ea8ff] hover:text-[#0f83fd]"
-              >
-                苦手ワードを見る →
-              </Link>
+              {isAuthenticated ? (
+                <Link
+                  to="/analysis"
+                  className="block text-center text-xs text-[#3ea8ff] hover:text-[#0f83fd]"
+                >
+                  苦手ワードを見る →
+                </Link>
+              ) : (
+                <p className="text-center text-xs text-slate-500">ログイン後に使えます</p>
+              )}
             </div>
           </div>
 
-          {/* Fingering */}
           <div className="app-card-soft flex flex-col gap-4 px-5 py-5">
             <div>
               <p className="text-sm font-semibold text-slate-900">苦手運指練習</p>
               <p className="mt-1 text-sm text-slate-500">ミス率の高いキー遷移パターンを練習します。</p>
-              {!isMockMode && bigramCount !== null && (
+              {isAuthenticated && !isMockMode && bigramCount !== null && (
                 <p className="mt-2 text-2xl font-bold text-slate-900">
                   {bigramCount}
                   <span className="ml-1 text-sm font-normal text-slate-400">パターン検出済み</span>
@@ -189,36 +180,69 @@ export function HomeScreen({
             <div className="mt-auto space-y-2">
               <button
                 onClick={() => void handleFingeringClick()}
-                disabled={isMockMode || startingFingering}
+                disabled={!isAuthenticated || isMockMode || startingFingering}
                 className="app-button app-button-secondary w-full"
-                title={isMockMode ? 'モック認証では利用できません' : undefined}
+                title={!isAuthenticated ? 'ログインすると利用できます' : isMockMode ? 'モック認証では利用できません' : undefined}
               >
                 {startingFingering && (
                   <span className="h-4 w-4 animate-spin rounded-full border-2 border-[#3ea8ff]/40 border-t-[#3ea8ff]" />
                 )}
                 練習開始
               </button>
-              <Link
-                to="/analysis"
-                className="block text-center text-xs text-[#3ea8ff] hover:text-[#0f83fd]"
-              >
-                運指データを見る →
-              </Link>
+              {isAuthenticated ? (
+                <Link
+                  to="/analysis"
+                  className="block text-center text-xs text-[#3ea8ff] hover:text-[#0f83fd]"
+                >
+                  運指データを見る →
+                </Link>
+              ) : (
+                <p className="text-center text-xs text-slate-500">ログイン後に使えます</p>
+              )}
             </div>
+          </div>
+
+          <div className="app-card-soft flex flex-col gap-4 px-5 py-5">
+            {isAuthenticated ? (
+              <>
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">{isAdmin ? '共有問題の管理' : 'ログイン中の機能'}</p>
+                  <p className="mt-1 text-sm text-slate-500">
+                    {isAdmin
+                      ? '共有の練習問題を追加・整理できます。'
+                      : '分析・統計・設定は上のメニューから利用できます。'}
+                  </p>
+                </div>
+                <div className="mt-auto space-y-2">
+                  {isAdmin ? (
+                    <Link to="/library" className="app-button app-button-secondary w-full justify-center">
+                      ライブラリを開く
+                    </Link>
+                  ) : (
+                    <Link to="/stats" className="app-button app-button-secondary w-full justify-center">
+                      統計を見る
+                    </Link>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">ログインするとできること</p>
+                  <p className="mt-1 text-sm text-slate-500">
+                    苦手ワード、運指分析、設定保存などの個人機能が使えるようになります。
+                  </p>
+                </div>
+                <div className="mt-auto space-y-2">
+                  <Link to="/login" className="app-button app-button-secondary w-full justify-center">
+                    Google でログイン
+                  </Link>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>
-
-      {showSentenceModal && (
-        <StartSessionModal
-          sentences={sentences}
-          onStart={(selectedSentences, sourceSentences, count, categories) => {
-            setShowSentenceModal(false)
-            onStartSentenceSession(selectedSentences, sourceSentences, count, categories)
-          }}
-          onClose={() => setShowSentenceModal(false)}
-        />
-      )}
     </DashboardLayout>
   )
 }

--- a/frontend/src/components/Layout/DashboardLayout.tsx
+++ b/frontend/src/components/Layout/DashboardLayout.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from 'react'
-import { NavLink } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 
 interface Props {
   title: string
   subtitle?: string
-  userName: string
-  onLogout: () => void
+  userName?: string
+  isAuthenticated?: boolean
+  isAdmin?: boolean
+  onLogout?: () => void
   actions?: ReactNode
   children: ReactNode
 }
@@ -23,10 +25,14 @@ export function DashboardLayout({
   title,
   subtitle,
   userName,
+  isAuthenticated,
+  isAdmin = false,
   onLogout,
   actions,
   children,
 }: Props) {
+  const signedIn = isAuthenticated ?? Boolean(userName)
+
   return (
     <div className="app-page flex flex-col">
       <header className="border-b border-[#d6e3ed]/80 bg-white/88 backdrop-blur">
@@ -41,31 +47,52 @@ export function DashboardLayout({
                 <NavLink to="/" end className={navLinkClassName}>
                   練習する
                 </NavLink>
-                <NavLink to="/analysis" className={navLinkClassName}>
-                  分析
-                </NavLink>
-                <NavLink to="/library" className={navLinkClassName}>
-                  ライブラリ
-                </NavLink>
-                <NavLink to="/stats" className={navLinkClassName}>
-                  統計
-                </NavLink>
-                <NavLink to="/settings" className={navLinkClassName}>
-                  設定
-                </NavLink>
+                {signedIn && (
+                  <>
+                    <NavLink to="/analysis" className={navLinkClassName}>
+                      分析
+                    </NavLink>
+                    <NavLink to="/stats" className={navLinkClassName}>
+                      統計
+                    </NavLink>
+                    <NavLink to="/settings" className={navLinkClassName}>
+                      設定
+                    </NavLink>
+                  </>
+                )}
+                {signedIn && isAdmin && (
+                  <NavLink to="/library" className={navLinkClassName}>
+                    ライブラリ
+                  </NavLink>
+                )}
               </nav>
             </div>
 
             <div className="flex flex-wrap items-center gap-3">
-              <div className="rounded-full border border-[#d6e3ed] bg-[#f8fbff] px-3 py-2 text-sm text-slate-600">
-                {userName}
-              </div>
-              <button
-                onClick={onLogout}
-                className="app-button app-button-subtle"
-              >
-                ログアウト
-              </button>
+              {signedIn && userName ? (
+                <>
+                  <div className="rounded-full border border-[#d6e3ed] bg-[#f8fbff] px-3 py-2 text-sm text-slate-600">
+                    {userName}
+                  </div>
+                  {onLogout && (
+                    <button
+                      onClick={onLogout}
+                      className="app-button app-button-subtle"
+                    >
+                      ログアウト
+                    </button>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div className="rounded-full border border-[#d6e3ed] bg-[#f8fbff] px-3 py-2 text-sm text-slate-600">
+                    ゲスト利用中
+                  </div>
+                  <Link to="/login" className="app-button app-button-primary">
+                    ログイン
+                  </Link>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/components/LoginScreen/LoginScreen.tsx
+++ b/frontend/src/components/LoginScreen/LoginScreen.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom'
+
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 
 interface Props {
@@ -13,19 +15,19 @@ export function LoginScreen({ error }: Props) {
             <div className="space-y-2">
               <p className="text-sm font-semibold uppercase tracking-[0.22em] text-[#3ea8ff]">typing-en</p>
               <h1 className="text-3xl font-bold leading-[1.5] text-slate-900 sm:text-4xl">
-                ミスを減らすための
+                登録なしでも始められる
                 <br />
                 英文タイピング練習
               </h1>
               <p className="max-w-2xl text-base text-slate-500">
-                練習結果から苦手ワードと運指パターンを抽出し、次に打つべき課題へ自然につなげる練習環境です。
+                まずは共有の練習問題でそのまま打てます。ログインすると、苦手ワードや運指分析、設定保存まで使えるようになります。
               </p>
             </div>
 
             <div className="grid gap-3 sm:grid-cols-3">
               <div className="app-card-soft px-4 py-4">
-                <p className="text-sm font-semibold text-slate-900">文章と単語を横断</p>
-                <p className="mt-1 text-sm text-slate-500">登録文、苦手ワード、ランダムワードを目的別に練習。</p>
+                <p className="text-sm font-semibold text-slate-900">通常練習 5 問</p>
+                <p className="mt-1 text-sm text-slate-500">共有の練習問題から、すぐに通常セッションを始められます。</p>
               </div>
               <div className="app-card-soft px-4 py-4">
                 <p className="text-sm font-semibold text-slate-900">苦手を自動分析</p>
@@ -33,15 +35,15 @@ export function LoginScreen({ error }: Props) {
               </div>
               <div className="app-card-soft px-4 py-4">
                 <p className="text-sm font-semibold text-slate-900">次の練習へ直結</p>
-                <p className="mt-1 text-sm text-slate-500">結果画面からそのまま苦手ワード練習やドリルへ。</p>
+                <p className="mt-1 text-sm text-slate-500">結果画面からそのまま次の練習へつなげられます。</p>
               </div>
             </div>
           </div>
 
           <div className="app-card-soft flex flex-col gap-2 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-sm font-semibold text-slate-900">Google アカウントでログイン</p>
-              <p className="text-sm text-slate-500">練習履歴と分析結果を保存して、ページをまたいで続けられます。</p>
+              <p className="text-sm font-semibold text-slate-900">ゲスト利用も、Google ログインも</p>
+              <p className="text-sm text-slate-500">まずは試して、続けるならログインして記録を残せます。</p>
             </div>
             <div className="app-chip app-chip-info">Accurate first</div>
           </div>
@@ -52,7 +54,7 @@ export function LoginScreen({ error }: Props) {
             <div className="app-chip app-chip-info">Sign in</div>
             <h2 className="text-2xl font-bold text-slate-900">練習をはじめる</h2>
             <p className="text-sm text-slate-500">
-              認証すると、文章管理・苦手ワード管理・結果の保存が利用できます。
+              ログインすると、苦手分析・統計・設定保存と、管理者向けの問題管理が利用できます。
             </p>
           </div>
 
@@ -78,11 +80,18 @@ export function LoginScreen({ error }: Props) {
           <div className="app-card-soft px-4 py-4">
             <p className="text-sm font-semibold text-slate-900">ログイン後にできること</p>
             <ul className="mt-2 space-y-1 text-sm text-slate-500">
-              <li>文章と攻略メモを管理</li>
               <li>苦手ワードと攻略済み状態を記録</li>
               <li>セッション結果から弱点を継続分析</li>
+              <li>管理者は共有問題を追加・編集</li>
             </ul>
           </div>
+
+          <Link
+            to="/"
+            className="app-button app-button-subtle w-full justify-center"
+          >
+            ログインせずに試す
+          </Link>
         </section>
       </div>
     </div>

--- a/frontend/src/components/PracticeScreen/PracticeScreen.tsx
+++ b/frontend/src/components/PracticeScreen/PracticeScreen.tsx
@@ -17,7 +17,8 @@ interface Props {
   sessionItems: SessionText[]
   onComplete: (result: SessionResult) => void
   onAbort: () => void
-  onLogout: () => void
+  onLogout?: () => void
+  canUseSavedSettings: boolean
   returnPath: string
 }
 
@@ -40,6 +41,7 @@ export function PracticeScreen({
   onComplete,
   onAbort,
   onLogout,
+  canUseSavedSettings,
   returnPath,
 }: Props) {
   const texts = sessionItems.map((item) => item.text)
@@ -47,7 +49,7 @@ export function PracticeScreen({
   const settingsLoading = useSettingsStore((state) => state.loading)
   const fetchSettings = useSettingsStore((state) => state.fetchSettings)
   const [settingsError, setSettingsError] = useState<string | null>(null)
-  const activeSettings = settings ?? DEFAULT_USER_SETTINGS
+  const activeSettings = canUseSavedSettings ? (settings ?? DEFAULT_USER_SETTINGS) : DEFAULT_USER_SETTINGS
   const { engineState, handleKey, phase, currentIndex, totalCount, result, sessionMisses } = useTypingSession(
     texts,
     activeSettings.missLockMs ?? DEFAULT_MISS_LOCK_MS,
@@ -69,6 +71,11 @@ export function PracticeScreen({
   )
 
   useEffect(() => {
+    if (!canUseSavedSettings) {
+      setSettingsError(null)
+      return () => undefined
+    }
+
     let cancelled = false
     setSettingsError(null)
 
@@ -81,7 +88,7 @@ export function PracticeScreen({
     return () => {
       cancelled = true
     }
-  }, [fetchSettings])
+  }, [canUseSavedSettings, fetchSettings])
 
   useEffect(() => {
     if (!engineState.lockedUntil) {
@@ -89,7 +96,8 @@ export function PracticeScreen({
       return
     }
 
-    const tick = () => setLockRemaining(Math.max(0, engineState.lockedUntil! - Date.now()))
+    const lockedUntil = engineState.lockedUntil
+    const tick = () => setLockRemaining(Math.max(0, lockedUntil - Date.now()))
     tick()
     const id = setInterval(tick, 50)
     return () => clearInterval(id)
@@ -115,9 +123,9 @@ export function PracticeScreen({
   const prevText = currentIndex > 0 ? texts[currentIndex - 1] : null
   const nextText = currentIndex < texts.length - 1 ? texts[currentIndex + 1] : null
   const isLast = currentIndex === totalCount - 1
-  const settingsReady = settings !== null
+  const settingsReady = !canUseSavedSettings || settings !== null
 
-  if (!settingsReady && settingsLoading) {
+  if (canUseSavedSettings && !settingsReady && settingsLoading) {
     return (
       <div className="app-page flex flex-col">
         <header className="border-b border-[#d6e3ed]/80 bg-white/88 backdrop-blur">
@@ -133,12 +141,14 @@ export function PracticeScreen({
               >
                 {getReturnLabel(returnPath)}
               </button>
-              <button
-                onClick={onLogout}
-                className="app-button app-button-subtle min-h-0 px-3 py-1.5 text-xs"
-              >
-                ログアウト
-              </button>
+              {onLogout && (
+                <button
+                  onClick={onLogout}
+                  className="app-button app-button-subtle min-h-0 px-3 py-1.5 text-xs"
+                >
+                  ログアウト
+                </button>
+              )}
             </div>
           </div>
         </header>
@@ -156,7 +166,7 @@ export function PracticeScreen({
     )
   }
 
-  if (!settingsReady && settingsError) {
+  if (canUseSavedSettings && !settingsReady && settingsError) {
     return (
       <div className="app-page flex flex-col">
         <header className="border-b border-[#d6e3ed]/80 bg-white/88 backdrop-blur">
@@ -172,12 +182,14 @@ export function PracticeScreen({
               >
                 {getReturnLabel(returnPath)}
               </button>
-              <button
-                onClick={onLogout}
-                className="app-button app-button-subtle min-h-0 px-3 py-1.5 text-xs"
-              >
-                ログアウト
-              </button>
+              {onLogout && (
+                <button
+                  onClick={onLogout}
+                  className="app-button app-button-subtle min-h-0 px-3 py-1.5 text-xs"
+                >
+                  ログアウト
+                </button>
+              )}
             </div>
           </div>
         </header>
@@ -231,12 +243,14 @@ export function PracticeScreen({
               penalty {activeSettings.missLockMs}ms / {activeSettings.penaltyResume === 'word' ? 'word' : 'current'}
             </div>
             <div className="app-chip app-chip-warning">Esc で中断</div>
-            <button
-              onClick={onLogout}
-              className="app-button app-button-subtle min-h-0 px-3 py-1.5 text-xs"
-            >
-              ログアウト
-            </button>
+            {onLogout && (
+              <button
+                onClick={onLogout}
+                className="app-button app-button-subtle min-h-0 px-3 py-1.5 text-xs"
+              >
+                ログアウト
+              </button>
+            )}
           </div>
         </div>
       </header>

--- a/frontend/src/components/ResultsScreen/ResultsScreen.tsx
+++ b/frontend/src/components/ResultsScreen/ResultsScreen.tsx
@@ -10,6 +10,7 @@ interface Props {
   onRestart: () => void
   onGoBack: () => void
   onStartWeakWordSession: () => Promise<void>
+  canStartWeakWordSession: boolean
   isMockMode: boolean
   returnLabel: string
 }
@@ -21,6 +22,7 @@ export function ResultsScreen({
   onRestart,
   onGoBack,
   onStartWeakWordSession,
+  canStartWeakWordSession,
   isMockMode,
   returnLabel,
 }: Props) {
@@ -50,6 +52,10 @@ export function ResultsScreen({
   }, [onRestart])
 
   const handleWeakWordClick = async () => {
+    if (!canStartWeakWordSession) {
+      return
+    }
+
     setStartingWeakWordSession(true)
     setWeakWordError(null)
     try {
@@ -98,13 +104,13 @@ export function ResultsScreen({
             </button>
             <button
               onClick={() => void handleWeakWordClick()}
-              disabled={isMockMode || startingWeakWordSession}
+              disabled={!canStartWeakWordSession || isMockMode || startingWeakWordSession}
               className="app-button app-button-secondary flex-1"
             >
               {startingWeakWordSession && (
                 <span className="h-4 w-4 animate-spin rounded-full border-2 border-[#3ea8ff]/40 border-t-[#3ea8ff]" />
               )}
-              苦手ワード練習
+              {canStartWeakWordSession ? '苦手ワード練習' : 'ログインで苦手ワード練習'}
             </button>
             <button
               onClick={onGoBack}

--- a/frontend/src/components/SentenceManager/SentenceManager.tsx
+++ b/frontend/src/components/SentenceManager/SentenceManager.tsx
@@ -135,7 +135,7 @@ export function SentenceManager({
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm font-semibold text-slate-900">カテゴリで絞り込む</p>
-                  <p className="text-xs text-slate-500">複数選択時は OR 条件で表示します。</p>
+                  <p className="text-xs text-slate-500">選んだカテゴリを含む文章を表示します。</p>
                 </div>
                 {filterCategories.length > 0 && (
                   <button

--- a/frontend/src/components/SettingsScreen/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen/SettingsScreen.tsx
@@ -177,7 +177,7 @@ export function SettingsScreen({ onLogout, userName }: Props) {
                 />
                 <div>
                   <p className="text-sm font-semibold text-slate-900">ミス文字から再開</p>
-                  <p className="text-sm text-slate-500">従来どおり、ミスした位置から打ち直します。</p>
+                  <p className="text-sm text-slate-500">ミスした文字の位置に戻って、その場から打ち直します。</p>
                 </div>
               </label>
               <label className="app-card-soft flex cursor-pointer items-start gap-3 px-4 py-4">

--- a/frontend/src/lib/publicSentences.ts
+++ b/frontend/src/lib/publicSentences.ts
@@ -1,0 +1,6 @@
+import type { SentenceList } from './sentences'
+import { apiFetch } from './api'
+
+export function fetchPublicPracticeSentences(count = 5): Promise<SentenceList> {
+  return apiFetch<SentenceList>(`/api/public/sentences?count=${count}`)
+}

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -4,6 +4,7 @@ interface User {
   id: string
   name: string
   email: string
+  isAdmin: boolean
 }
 
 interface AuthState {


### PR DESCRIPTION
## Summary
- expose shared practice sentences through a public API and restrict sentence management to admin Gmail accounts from `.env`
- replace the guest landing flow with a five-question normal practice session based on shared sentences
- gate analysis, stats, settings, and library management by login/admin state and refresh the related copy/docs

## Validation
- cd backend && npx prisma generate && npm run build
- cd frontend && npm test -- --run && npm run build