### PR TITLE
docs: 環境別セットアップドキュメントの整備 (#21)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,11 @@ CLOUDFLARE_TUNNEL_TOKEN=your-cloudflare-tunnel-token
 
 # ---- 開発用オプション ----
 # AUTH_MOCK=true にすると Google OAuth 認証をスキップし、ダミーユーザーでログイン扱いになる
-# ローカル開発で Google 認証情報なしに動かしたい場合に使用
+# フロントエンド側でも VITE_AUTH_MOCK=true が必要（全コンテナ構成ではこのファイルから両方渡される）
+# ローカル実行の場合は backend は .env の AUTH_MOCK、frontend は frontend/.env.local に VITE_AUTH_MOCK を設定する
+# 本番環境では有効にしないこと
 # AUTH_MOCK=true
+# VITE_AUTH_MOCK=true
 
 # =============================================================================
 # BUILD-TIME VARIABLES — GitHub Actions Secret として設定すること
@@ -55,3 +58,4 @@ CLOUDFLARE_TUNNEL_TOKEN=your-cloudflare-tunnel-token
 # → GitHub Actions Secret "VITE_API_URL" に設定する
 
 # VITE_AUTH_MOCK — 本番では不要。ローカル開発時のみ frontend/.env.local に設定。
+#   全コンテナ構成（docker-compose.yml）では .env の VITE_AUTH_MOCK がビルド時に渡される。

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
 # =============================================================================
 # RUNTIME VARIABLES — サーバー上で .env としてコピーして使う
-# docker-compose.prod.yml がコンテナ起動時に読み込む
 # =============================================================================
 
 # ---- Google OAuth 2.0 ----
 # https://console.cloud.google.com/apis/credentials でCredential作成
-# 承認済みリダイレクト URI: https://api.your-domain.com/auth/google/callback
+# 承認済みリダイレクト URI:
+#   本番: https://api.your-domain.com/auth/google/callback
+#   開発: http://localhost:3000/auth/google/callback
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_CALLBACK_URL=https://api.your-domain.com/auth/google/callback
@@ -21,7 +22,13 @@ MYSQL_USER=typing_user
 MYSQL_PASSWORD=strong-user-password
 
 # ---- Backend ----
-DATABASE_URL=mysql://typing_user:strong-user-password@mysql:3306/typing_en
+# DATABASE_URL のホスト名に注意:
+#   本番 / 全コンテナ開発環境 (docker-compose.yml):
+#     → docker-compose.yml が自動で mysql ホスト名を使うため、この値は参照されない
+#   MySQL のみコンテナ + ローカル実行 (pnpm run dev):
+#     → localhost:3306 を使う
+DATABASE_URL=mysql://typing_user:strong-user-password@localhost:3306/typing_en
+
 PORT=3000
 # フロントエンドの公開 URL（CORS 設定に使用）
 FRONTEND_URL=https://your-domain.com
@@ -29,8 +36,13 @@ FRONTEND_URL=https://your-domain.com
 ADMIN_GOOGLE_EMAILS=admin1@gmail.com,admin2@gmail.com
 
 # ---- Cloudflare Tunnel ----
-# Zero Trust ダッシュボード → Tunnels でトークンを取得
+# Zero Trust ダッシュボード → Tunnels でトークンを取得（本番のみ必要）
 CLOUDFLARE_TUNNEL_TOKEN=your-cloudflare-tunnel-token
+
+# ---- 開発用オプション ----
+# AUTH_MOCK=true にすると Google OAuth 認証をスキップし、ダミーユーザーでログイン扱いになる
+# ローカル開発で Google 認証情報なしに動かしたい場合に使用
+# AUTH_MOCK=true
 
 # =============================================================================
 # BUILD-TIME VARIABLES — GitHub Actions Secret として設定すること

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ MYSQL_PASSWORD=typing_password
 PORT=3000
 FRONTEND_URL=http://localhost:5173
 ADMIN_GOOGLE_EMAILS=your-email@gmail.com
+
+# Google 認証情報なしで動かす場合（任意）— 詳細は下記「AUTH_MOCK モードについて」を参照
+# AUTH_MOCK=true
+# VITE_AUTH_MOCK=true
 ```
 
 > **Note**: `docker-compose.yml` はコンテナ内のMySQLに自動接続するため、`DATABASE_URL` の設定は不要です。
@@ -177,7 +181,29 @@ pnpm run dev
 
 #### AUTH_MOCK モードについて
 
-`AUTH_MOCK=true` を `.env` に設定すると Google OAuth 認証をスキップし、固定のダミーユーザーとしてログイン状態になります。Google Cloud Console での設定なしにアプリ全体を動かしたい場合に便利です。
+Google Cloud Console の設定なしにアプリ全体を動かしたい場合に使用するモックフラグです。  
+**バックエンドとフロントエンドの両方で設定が必要です。**
+
+| 場所 | 変数 | 値 |
+|---|---|---|
+| `.env`（バックエンド用） | `AUTH_MOCK` | `true` |
+| `frontend/.env.local`（フロントエンド用） | `VITE_AUTH_MOCK` | `true` |
+
+**Section B（全コンテナ）の場合**: `.env` に両方を設定すると `docker-compose.yml` が各コンテナへ自動的に渡します。
+
+**Section C（ローカル実行）の場合**: `.env` の `AUTH_MOCK=true` に加え、以下のファイルを作成してください。
+
+```ini
+# frontend/.env.local
+VITE_AUTH_MOCK=true
+```
+
+有効にすると:
+- フロントエンドが Google ログイン画面を表示せず、自動的にダミーユーザー（`mock@example.com`）でログイン状態になります
+- バックエンドが `mock-token` を有効な認証トークンとして扱い、ダミーユーザーへのAPIアクセスを許可します
+- ダミーユーザーには管理者権限が付与されます（管理機能の動作確認が可能）
+
+> **注意**: 本番環境では絶対に有効にしないでください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,36 +20,164 @@
 
 ## セットアップ
 
-### 前提条件
+3つの構成パターンに対応しています。目的に合わせて選択してください。
 
-- Docker / Docker Compose
-- Google Cloud Console でのOAuth 2.0 認証情報
+---
 
-### 手順
+### A. 本番サーバー環境
+
+**前提条件**: Docker / Docker Compose、独自ドメイン、Cloudflare Tunnel、Google OAuth 2.0 認証情報
 
 ```bash
 # 1. リポジトリをクローン
-git clone https://github.com/your-username/typing-en.git
+git clone https://github.com/ktakahiro150397/typing-en.git
 cd typing-en
 
 # 2. 環境変数を設定
 cp .env.example .env
-# .env を編集して以下を設定:
-#   GOOGLE_CLIENT_ID=...
-#   GOOGLE_CLIENT_SECRET=...
-#   JWT_SECRET=...
-#   MYSQL_ROOT_PASSWORD=...
-#   ADMIN_GOOGLE_EMAILS=admin1@gmail.com,admin2@gmail.com
-
-# 3. 起動
-docker compose up -d
-
-# 4. DBマイグレーション
-docker compose exec backend npx prisma migrate deploy
 ```
 
-フロントエンド: http://localhost:5173
+`.env` を編集して以下を設定:
+
+| 変数 | 説明 |
+|---|---|
+| `GOOGLE_CLIENT_ID` | Google Cloud Console で取得 |
+| `GOOGLE_CLIENT_SECRET` | Google Cloud Console で取得 |
+| `GOOGLE_CALLBACK_URL` | `https://api.your-domain.com/auth/google/callback` |
+| `JWT_SECRET` | `openssl rand -hex 32` で生成（32文字以上） |
+| `MYSQL_ROOT_PASSWORD` | 強力なパスワード |
+| `MYSQL_USER` / `MYSQL_PASSWORD` | DBユーザー情報 |
+| `MYSQL_DATABASE` | `typing_en` |
+| `FRONTEND_URL` | `https://your-domain.com` |
+| `ADMIN_GOOGLE_EMAILS` | 管理者Gmailアドレス（カンマ区切り） |
+| `CLOUDFLARE_TUNNEL_TOKEN` | Cloudflare Zero Trust ダッシュボードで取得 |
+
+> **Note**: `DATABASE_URL` は `docker-compose.prod.yml` の `env_file: .env` で読まれます。ホスト名は `mysql`（Dockerサービス名）にしてください。
+> 例: `DATABASE_URL=mysql://typing_user:password@mysql:3306/typing_en`
+
+```bash
+# 3. 起動（ビルド済みイメージを使用）
+docker compose -f docker-compose.prod.yml up -d
+
+# 4. 状態確認
+docker compose -f docker-compose.prod.yml logs -f backend
+```
+
+フロントエンドの `VITE_API_URL` はGitHub Actions Secretとして管理され、ビルド時に埋め込まれます。
+
+---
+
+### B. 開発環境 — 全てコンテナで動作させる場合
+
+**前提条件**: Docker / Docker Compose のみ
+
+```bash
+# 1. リポジトリをクローン
+git clone https://github.com/ktakahiro150397/typing-en.git
+cd typing-en
+
+# 2. 環境変数を設定
+cp .env.example .env
+```
+
+`.env` を最低限以下の内容で設定:
+
+```ini
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+JWT_SECRET=your-jwt-secret-at-least-32-chars
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=typing_en
+MYSQL_USER=typing_user
+MYSQL_PASSWORD=typing_password
+PORT=3000
+FRONTEND_URL=http://localhost:5173
+ADMIN_GOOGLE_EMAILS=your-email@gmail.com
+```
+
+> **Note**: `docker-compose.yml` はコンテナ内のMySQLに自動接続するため、`DATABASE_URL` の設定は不要です。
+
+```bash
+# 3. 起動（初回はイメージビルドを含む）
+docker compose up -d
+
+# 4. ログ確認
+docker compose logs -f backend
+```
+
+フロントエンド: http://localhost:5173  
 バックエンドAPI: http://localhost:3000
+
+---
+
+### C. 開発環境 — MySQLのみコンテナ、フロント/バックはローカル実行
+
+ホットリロードを活かしたコード編集向けの構成です。
+
+**前提条件**: Docker / Docker Compose + Node.js 22+ + [pnpm](https://pnpm.io/)
+
+```bash
+# pnpm のインストール（未導入の場合）
+npm install -g pnpm
+```
+
+```bash
+# 1. リポジトリをクローン
+git clone https://github.com/ktakahiro150397/typing-en.git
+cd typing-en
+
+# 2. 環境変数を設定
+cp .env.example .env
+```
+
+`.env` を以下の内容で設定:
+
+```ini
+# Google OAuth（AUTH_MOCK=true を使う場合は不要）
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+
+JWT_SECRET=your-jwt-secret-at-least-32-chars
+
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=typing_en
+MYSQL_USER=typing_user
+MYSQL_PASSWORD=typing_password
+
+# ローカル実行では localhost を使用（コンテナ内とは異なる）
+DATABASE_URL=mysql://typing_user:typing_password@localhost:3306/typing_en
+
+PORT=3000
+FRONTEND_URL=http://localhost:5173
+ADMIN_GOOGLE_EMAILS=your-email@gmail.com
+
+# Google 認証情報なしで動かす場合（任意）
+# AUTH_MOCK=true
+```
+
+```bash
+# 3. MySQLコンテナのみ起動
+docker compose up mysql -d
+
+# 4. バックエンドをローカルで起動（別ターミナル）
+cd backend
+pnpm install
+pnpm run dev
+
+# 5. フロントエンドをローカルで起動（別ターミナル）
+cd frontend
+pnpm install
+pnpm run dev
+```
+
+フロントエンド: http://localhost:5173  
+バックエンドAPI: http://localhost:3000
+
+#### AUTH_MOCK モードについて
+
+`AUTH_MOCK=true` を `.env` に設定すると Google OAuth 認証をスキップし、固定のダミーユーザーとしてログイン状態になります。Google Cloud Console での設定なしにアプリ全体を動かしたい場合に便利です。
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql:3306/${MYSQL_DATABASE}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GOOGLE_CALLBACK_URL: ${GOOGLE_CALLBACK_URL}
@@ -31,6 +31,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL}
       PORT: ${PORT}
       AUTH_MOCK: ${AUTH_MOCK:-false}
+      ADMIN_GOOGLE_EMAILS: ${ADMIN_GOOGLE_EMAILS}
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- README.mdに本番・全コンテナ開発・MySQLのみコンテナの3パターンのセットアップ手順を詳細記載
- `docker-compose.yml` のバグ修正: バックエンドの `DATABASE_URL` が `.env` の `localhost` に依存していたため全コンテナ構成で接続失敗していた問題を、コンテナ内では `mysql` ホスト名を直接使うよう修正
- `docker-compose.yml` に `ADMIN_GOOGLE_EMAILS` 環境変数が渡されていなかった問題を修正
- `.env.example` に `AUTH_MOCK` オプションと各環境でのDATABASE_URLの違いを追記

## Root cause

`docker-compose.yml` は `DATABASE_URL: ${DATABASE_URL}` で `.env` を読んでいたが、`.env` には `localhost:3306` が入っていた。Docker内部ネットワークではMySQLは `mysql:3306` でしかアクセスできないため、全コンテナ構成で起動できなかった。

## Test plan

- [ ] `docker compose up -d` で全コンテナ起動 → backendがmysqlに接続できる
- [ ] `docker compose up mysql -d` + `pnpm run dev` でMySQLのみコンテナ構成が動作する
- [ ] READMEの手順に沿って初回セットアップできることを確認

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized setup into three deployment patterns (production and two development modes)
  * Removed explicit DB migration step from quick-start; emphasized start and log-check workflows
  * Clarified database host differences (container vs localhost), OAuth callback URLs for prod/dev, and Cloudflare Tunnel token usage
  * Added documented mock-auth option for local development (with caution to not enable in production)
* **Chores**
  * Added environment variable for admin Google emails configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->